### PR TITLE
一旦mediasoup を0.8.0に固定

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,9 +209,9 @@ checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
 
 [[package]]
 name = "futures-lite"
-version = "1.11.3"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4481d0cd0de1d204a4fa55e7d45f07b1d958abcb06714b3446438e2eff695fb"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -317,9 +317,9 @@ checksum = "1f374d42cdfc1d7dbf3d3dec28afab2eb97ffbf43a3234d795b5986dbf4b90ba"
 
 [[package]]
 name = "mediasoup"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c93c664c3a9bdbbc254893cee3786eee3bd451ad6e0a5db5f45cd8c1e93864b9"
+checksum = "3fafaa6b180e36a8262d066838a0830206f0db66d854ef8464b30d319f58df5c"
 dependencies = [
  "async-channel",
  "async-executor",
@@ -349,9 +349,9 @@ dependencies = [
 
 [[package]]
 name = "mediasoup-sys"
-version = "0.1.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd12f448a10108f2fe27cc72b49c0e29d44556dc7e957c86635ac8ec77bba73"
+checksum = "6dce5fd5c3040c05146e15d99a3e387c3ceff4c225f5228b98f05f7a2e2029ad"
 
 [[package]]
 name = "mediasoup_elixir"
@@ -465,9 +465,9 @@ dependencies = [
 
 [[package]]
 name = "quick-error"
-version = "1.2.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"

--- a/native/mediasoup_elixir/Cargo.toml
+++ b/native/mediasoup_elixir/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 [dependencies]
 rustler = "0.22.0"
 once_cell = "1.7.2"
-mediasoup = "0.8.0"
+mediasoup = "= 0.8.0"
 futures-lite = "1.12.0"
 serde = { version = "1.0.125", features = ["derive"] }
 serde-transcode = "1.1"


### PR DESCRIPTION
for workaround build error at stable rust


#24