### PR TITLE
refactor: remove unwrap

### DIFF
--- a/native/mediasoup_elixir/src/atoms.rs
+++ b/native/mediasoup_elixir/src/atoms.rs
@@ -2,6 +2,7 @@ rustler::atoms! {
     ok,
     error,
     terminated,
+    poison_error,
     on_new_router,
     on_close,
     on_dead,

--- a/native/mediasoup_elixir/src/consumer.rs
+++ b/native/mediasoup_elixir/src/consumer.rs
@@ -35,9 +35,7 @@ impl ConsumerStruct {
 
 #[rustler::nif]
 pub fn consumer_id(consumer: ResourceArc<ConsumerRef>) -> NifResult<JsonSerdeWrap<ConsumerId>> {
-    let consumer = consumer
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let consumer = consumer.get_resource()?;
     Ok(consumer.id().into())
 }
 #[rustler::nif]
@@ -47,59 +45,45 @@ pub fn consumer_close(consumer: ResourceArc<ConsumerRef>) -> NifResult<(Atom,)> 
 }
 #[rustler::nif]
 pub fn consumer_closed(consumer: ResourceArc<ConsumerRef>) -> NifResult<bool> {
-    let consumer = consumer
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let consumer = consumer.get_resource()?;
     Ok(consumer.closed())
 }
 
 #[rustler::nif]
 pub fn consumer_paused(consumer: ResourceArc<ConsumerRef>) -> NifResult<bool> {
-    let consumer = consumer
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let consumer = consumer.get_resource()?;
     Ok(consumer.paused())
 }
 
 #[rustler::nif]
 pub fn consumer_producer_paused(consumer: ResourceArc<ConsumerRef>) -> NifResult<bool> {
-    let consumer = consumer
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let consumer = consumer.get_resource()?;
     Ok(consumer.producer_paused())
 }
 #[rustler::nif]
 pub fn consumer_priority(consumer: ResourceArc<ConsumerRef>) -> NifResult<u8> {
-    let consumer = consumer
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let consumer = consumer.get_resource()?;
     Ok(consumer.priority())
 }
 #[rustler::nif]
 pub fn consumer_score(
     consumer: ResourceArc<ConsumerRef>,
 ) -> NifResult<JsonSerdeWrap<ConsumerScore>> {
-    let consumer = consumer
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let consumer = consumer.get_resource()?;
     Ok(JsonSerdeWrap::new(consumer.score()))
 }
 #[rustler::nif]
 pub fn consumer_preferred_layers(
     consumer: ResourceArc<ConsumerRef>,
 ) -> NifResult<JsonSerdeWrap<Option<ConsumerLayers>>> {
-    let consumer = consumer
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let consumer = consumer.get_resource()?;
     Ok(JsonSerdeWrap::new(consumer.preferred_layers()))
 }
 #[rustler::nif]
 pub fn consumer_current_layers(
     consumer: ResourceArc<ConsumerRef>,
 ) -> NifResult<JsonSerdeWrap<Option<ConsumerLayers>>> {
-    let consumer = consumer
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let consumer = consumer.get_resource()?;
     Ok(JsonSerdeWrap::new(consumer.current_layers()))
 }
 
@@ -107,9 +91,7 @@ pub fn consumer_current_layers(
 pub fn consumer_get_stats(
     consumer: ResourceArc<ConsumerRef>,
 ) -> NifResult<JsonSerdeWrap<ConsumerStats>> {
-    let consumer = consumer
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let consumer = consumer.get_resource()?;
     let status = future::block_on(async move {
         return consumer.get_stats().await;
     })
@@ -119,9 +101,7 @@ pub fn consumer_get_stats(
 }
 #[rustler::nif]
 pub fn consumer_pause(consumer: ResourceArc<ConsumerRef>) -> NifResult<(Atom,)> {
-    let consumer = consumer
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let consumer = consumer.get_resource()?;
 
     future::block_on(async move {
         return consumer.pause().await;
@@ -131,9 +111,7 @@ pub fn consumer_pause(consumer: ResourceArc<ConsumerRef>) -> NifResult<(Atom,)> 
 }
 #[rustler::nif]
 pub fn consumer_resume(consumer: ResourceArc<ConsumerRef>) -> NifResult<(Atom,)> {
-    let consumer = consumer
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let consumer = consumer.get_resource()?;
 
     future::block_on(async move {
         return consumer.resume().await;
@@ -147,9 +125,7 @@ pub fn consumer_set_preferred_layers(
     consumer: ResourceArc<ConsumerRef>,
     layer: JsonSerdeWrap<ConsumerLayers>,
 ) -> NifResult<(Atom,)> {
-    let consumer = consumer
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let consumer = consumer.get_resource()?;
 
     future::block_on(async move {
         return consumer.set_preferred_layers(*layer).await;
@@ -163,9 +139,7 @@ pub fn consumer_set_priority(
     consumer: ResourceArc<ConsumerRef>,
     priority: u8,
 ) -> NifResult<(Atom,)> {
-    let consumer = consumer
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let consumer = consumer.get_resource()?;
     future::block_on(async move {
         return consumer.set_priority(priority).await;
     })
@@ -174,9 +148,7 @@ pub fn consumer_set_priority(
 }
 #[rustler::nif]
 pub fn consumer_unset_priority(consumer: ResourceArc<ConsumerRef>) -> NifResult<(Atom,)> {
-    let consumer = consumer
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let consumer = consumer.get_resource()?;
 
     future::block_on(async move {
         return consumer.unset_priority().await;
@@ -187,9 +159,7 @@ pub fn consumer_unset_priority(consumer: ResourceArc<ConsumerRef>) -> NifResult<
 
 #[rustler::nif]
 pub fn consumer_request_key_frame(consumer: ResourceArc<ConsumerRef>) -> NifResult<(Atom,)> {
-    let consumer = consumer
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let consumer = consumer.get_resource()?;
 
     future::block_on(async move {
         return consumer.request_key_frame().await;
@@ -200,9 +170,7 @@ pub fn consumer_request_key_frame(consumer: ResourceArc<ConsumerRef>) -> NifResu
 
 #[rustler::nif]
 pub fn consumer_dump(consumer: ResourceArc<ConsumerRef>) -> NifResult<JsonSerdeWrap<ConsumerDump>> {
-    let consumer = consumer
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let consumer = consumer.get_resource()?;
 
     let dump = future::block_on(async move {
         return consumer.dump().await;
@@ -217,9 +185,7 @@ pub fn consumer_event(
     consumer: ResourceArc<ConsumerRef>,
     pid: rustler::LocalPid,
 ) -> NifResult<(Atom,)> {
-    let consumer = consumer
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let consumer = consumer.get_resource()?;
 
     crate::reg_callback!(pid, consumer, on_close);
     crate::reg_callback!(pid, consumer, on_pause);

--- a/native/mediasoup_elixir/src/producer.rs
+++ b/native/mediasoup_elixir/src/producer.rs
@@ -22,9 +22,7 @@ impl ProducerStruct {
 
 #[rustler::nif]
 pub fn producer_id(producer: ResourceArc<ProducerRef>) -> NifResult<String> {
-    let producer = producer
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let producer = producer.get_resource()?;
     Ok(producer.id().to_string())
 }
 
@@ -35,9 +33,7 @@ pub fn producer_close(producer: ResourceArc<ProducerRef>) -> NifResult<(Atom,)> 
 }
 #[rustler::nif]
 pub fn producer_pause(producer: ResourceArc<ProducerRef>) -> NifResult<(rustler::Atom,)> {
-    let producer = producer
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let producer = producer.get_resource()?;
 
     future::block_on(async move {
         return producer.pause().await;
@@ -47,9 +43,7 @@ pub fn producer_pause(producer: ResourceArc<ProducerRef>) -> NifResult<(rustler:
 }
 #[rustler::nif]
 pub fn producer_resume(producer: ResourceArc<ProducerRef>) -> NifResult<(rustler::Atom,)> {
-    let producer = producer
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let producer = producer.get_resource()?;
 
     future::block_on(async move {
         return producer.resume().await;
@@ -60,9 +54,7 @@ pub fn producer_resume(producer: ResourceArc<ProducerRef>) -> NifResult<(rustler
 
 #[rustler::nif]
 pub fn producer_dump(producer: ResourceArc<ProducerRef>) -> NifResult<JsonSerdeWrap<ProducerDump>> {
-    let producer = producer
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let producer = producer.get_resource()?;
 
     let dump = future::block_on(async move {
         return producer.dump().await;
@@ -76,9 +68,7 @@ pub fn producer_event(
     producer: ResourceArc<ProducerRef>,
     pid: rustler::LocalPid,
 ) -> NifResult<(rustler::Atom,)> {
-    let producer = producer
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let producer = producer.get_resource()?;
 
     crate::reg_callback!(pid, producer, on_close);
     crate::reg_callback!(pid, producer, on_pause);

--- a/native/mediasoup_elixir/src/router.rs
+++ b/native/mediasoup_elixir/src/router.rs
@@ -29,9 +29,7 @@ impl RouterStruct {
 
 #[rustler::nif]
 pub fn router_id(router: ResourceArc<RouterRef>) -> NifResult<String> {
-    let router = router
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let router = router.get_resource()?;
     Ok(router.id().to_string())
 }
 #[rustler::nif]
@@ -44,9 +42,7 @@ pub fn router_create_webrtc_transport(
     router: ResourceArc<RouterRef>,
     option: SerWebRtcTransportOptions,
 ) -> NifResult<(rustler::Atom, WebRtcTransportStruct)> {
-    let router = router
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let router = router.get_resource()?;
     let option = option.try_to_option().map_err(|e| Error::RaiseAtom(e))?;
 
     let transport = future::block_on(async move {
@@ -60,9 +56,7 @@ pub fn router_create_webrtc_transport(
 pub fn router_rtp_capabilities(
     router: ResourceArc<RouterRef>,
 ) -> NifResult<JsonSerdeWrap<RtpCapabilitiesFinalized>> {
-    let router = router
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let router = router.get_resource()?;
 
     Ok(JsonSerdeWrap::new(router.rtp_capabilities().clone()))
 }
@@ -73,9 +67,7 @@ pub fn router_can_consume(
     producer_id: JsonSerdeWrap<ProducerId>,
     rtp_capabilities: JsonSerdeWrap<RtpCapabilities>,
 ) -> NifResult<bool> {
-    let router = router
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let router = router.get_resource()?;
     let producer_id = *producer_id;
     let rtp_capabilities = rtp_capabilities.clone();
 
@@ -84,9 +76,7 @@ pub fn router_can_consume(
 }
 #[rustler::nif]
 pub fn router_dump(router: ResourceArc<RouterRef>) -> NifResult<JsonSerdeWrap<RouterDump>> {
-    let router = router
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let router = router.get_resource()?;
     let dump = future::block_on(async move {
         return router.dump().await;
     })
@@ -100,9 +90,7 @@ pub fn router_event(
     router: ResourceArc<RouterRef>,
     pid: rustler::LocalPid,
 ) -> NifResult<(rustler::Atom,)> {
-    let router = router
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let router = router.get_resource()?;
 
     crate::reg_callback!(pid, router, on_close);
     crate::reg_callback!(pid, router, on_worker_close);

--- a/native/mediasoup_elixir/src/webrtc_transport.rs
+++ b/native/mediasoup_elixir/src/webrtc_transport.rs
@@ -35,9 +35,7 @@ impl WebRtcTransportStruct {
 
 #[rustler::nif]
 pub fn webrtc_transport_id(transport: ResourceArc<WebRtcTransportRef>) -> NifResult<String> {
-    let transport = transport
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let transport = transport.get_resource()?;
     Ok(transport.id().to_string())
 }
 
@@ -52,9 +50,7 @@ pub fn webrtc_transport_consume(
     transport: ResourceArc<WebRtcTransportRef>,
     ser_option: SerConsumerOptions,
 ) -> NifResult<(Atom, ConsumerStruct)> {
-    let transport = transport
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let transport = transport.get_resource()?;
 
     let option = ConsumerOptions::from(ser_option);
 
@@ -71,9 +67,7 @@ pub fn webrtc_transport_connect(
     transport: ResourceArc<WebRtcTransportRef>,
     option: JsonSerdeWrap<WebRtcTransportRemoteParameters>,
 ) -> NifResult<(Atom,)> {
-    let transport = transport
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let transport = transport.get_resource()?;
     let option: WebRtcTransportRemoteParameters = option.clone();
 
     future::block_on(async move {
@@ -88,9 +82,7 @@ pub fn webrtc_transport_produce(
     transport: ResourceArc<WebRtcTransportRef>,
     option: SerProducerOptions,
 ) -> NifResult<(Atom, ProducerStruct)> {
-    let transport = transport
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let transport = transport.get_resource()?;
     let option = ProducerOptions::from(option);
 
     let producer = future::block_on(async move {
@@ -104,9 +96,7 @@ pub fn webrtc_transport_produce(
 pub fn webrtc_transport_ice_parameters(
     transport: ResourceArc<WebRtcTransportRef>,
 ) -> NifResult<JsonSerdeWrap<IceParameters>> {
-    let transport = transport
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let transport = transport.get_resource()?;
     Ok(JsonSerdeWrap::new(transport.ice_parameters().clone()))
 }
 
@@ -114,9 +104,7 @@ pub fn webrtc_transport_ice_parameters(
 pub fn webrtc_transport_sctp_parameters(
     transport: ResourceArc<WebRtcTransportRef>,
 ) -> NifResult<JsonSerdeWrap<Option<SctpParameters>>> {
-    let transport = transport
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let transport = transport.get_resource()?;
     Ok(JsonSerdeWrap::new(transport.sctp_parameters().clone()))
 }
 
@@ -124,9 +112,7 @@ pub fn webrtc_transport_sctp_parameters(
 pub fn webrtc_transport_ice_candidates(
     transport: ResourceArc<WebRtcTransportRef>,
 ) -> NifResult<JsonSerdeWrap<std::vec::Vec<mediasoup::data_structures::IceCandidate>>> {
-    let transport = transport
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let transport = transport.get_resource()?;
     Ok(JsonSerdeWrap::new(transport.ice_candidates().clone()))
 }
 
@@ -134,9 +120,7 @@ pub fn webrtc_transport_ice_candidates(
 pub fn webrtc_transport_ice_role(
     transport: ResourceArc<WebRtcTransportRef>,
 ) -> NifResult<JsonSerdeWrap<IceRole>> {
-    let transport = transport
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let transport = transport.get_resource()?;
     Ok(JsonSerdeWrap::new(transport.ice_role()))
 }
 
@@ -145,9 +129,7 @@ pub fn webrtc_transport_set_max_incoming_bitrate(
     transport: ResourceArc<WebRtcTransportRef>,
     bitrate: u32,
 ) -> NifResult<(Atom,)> {
-    let transport = transport
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let transport = transport.get_resource()?;
 
     future::block_on(async move {
         return transport.set_max_incoming_bitrate(bitrate).await;
@@ -161,9 +143,7 @@ pub fn webrtc_transport_set_max_outgoing_bitrate(
     transport: ResourceArc<WebRtcTransportRef>,
     bitrate: u32,
 ) -> NifResult<(Atom,)> {
-    let transport = transport
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let transport = transport.get_resource()?;
 
     future::block_on(async move {
         return transport.set_max_outgoing_bitrate(bitrate).await;
@@ -176,9 +156,7 @@ pub fn webrtc_transport_set_max_outgoing_bitrate(
 pub fn webrtc_transport_ice_state(
     transport: ResourceArc<WebRtcTransportRef>,
 ) -> NifResult<JsonSerdeWrap<IceState>> {
-    let transport = transport
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let transport = transport.get_resource()?;
     Ok(JsonSerdeWrap::new(transport.ice_state()))
 }
 
@@ -186,9 +164,7 @@ pub fn webrtc_transport_ice_state(
 pub fn webrtc_transport_restart_ice(
     transport: ResourceArc<WebRtcTransportRef>,
 ) -> NifResult<(Atom, JsonSerdeWrap<IceParameters>)> {
-    let transport = transport
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let transport = transport.get_resource()?;
 
     let ice_parameter = future::block_on(async move {
         return transport.restart_ice().await;
@@ -202,9 +178,7 @@ pub fn webrtc_transport_restart_ice(
 pub fn webrtc_transport_get_stats(
     transport: ResourceArc<WebRtcTransportRef>,
 ) -> NifResult<JsonSerdeWrap<std::vec::Vec<WebRtcTransportStat>>> {
-    let transport = transport
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let transport = transport.get_resource()?;
 
     let status = future::block_on(async move {
         return transport.get_stats().await;
@@ -218,9 +192,7 @@ pub fn webrtc_transport_get_stats(
 pub fn webrtc_transport_dump(
     transport: ResourceArc<WebRtcTransportRef>,
 ) -> NifResult<JsonSerdeWrap<WebRtcTransportDump>> {
-    let transport = transport
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let transport = transport.get_resource()?;
 
     let dump = future::block_on(async move {
         return transport.dump().await;
@@ -234,9 +206,7 @@ pub fn webrtc_transport_dump(
 pub fn webrtc_transport_ice_selected_tuple(
     transport: ResourceArc<WebRtcTransportRef>,
 ) -> NifResult<JsonSerdeWrap<Option<TransportTuple>>> {
-    let transport = transport
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let transport = transport.get_resource()?;
     Ok(JsonSerdeWrap::new(transport.ice_selected_tuple()))
 }
 
@@ -244,9 +214,7 @@ pub fn webrtc_transport_ice_selected_tuple(
 pub fn webrtc_transport_dtls_parameters(
     transport: ResourceArc<WebRtcTransportRef>,
 ) -> NifResult<JsonSerdeWrap<DtlsParameters>> {
-    let transport = transport
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let transport = transport.get_resource()?;
     Ok(JsonSerdeWrap::new(transport.dtls_parameters()))
 }
 
@@ -254,18 +222,14 @@ pub fn webrtc_transport_dtls_parameters(
 pub fn webrtc_transport_dtls_state(
     transport: ResourceArc<WebRtcTransportRef>,
 ) -> NifResult<JsonSerdeWrap<DtlsState>> {
-    let transport = transport
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let transport = transport.get_resource()?;
     Ok(JsonSerdeWrap::new(transport.dtls_state()))
 }
 #[rustler::nif]
 pub fn webrtc_transport_sctp_state(
     transport: ResourceArc<WebRtcTransportRef>,
 ) -> NifResult<JsonSerdeWrap<Option<SctpState>>> {
-    let transport = transport
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let transport = transport.get_resource()?;
     Ok(JsonSerdeWrap::new(transport.sctp_state()))
 }
 
@@ -274,9 +238,7 @@ pub fn webrtc_transport_event(
     transport: ResourceArc<WebRtcTransportRef>,
     pid: rustler::LocalPid,
 ) -> NifResult<(Atom,)> {
-    let transport = transport
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let transport = transport.get_resource()?;
 
     //    crate::reg_callback!(env, transport, on_close);
 

--- a/native/mediasoup_elixir/src/worker.rs
+++ b/native/mediasoup_elixir/src/worker.rs
@@ -34,10 +34,9 @@ static WORKER_MANAGER: Lazy<Mutex<WorkerManager>> = Lazy::new(|| Mutex::new(Work
 
 #[rustler::nif]
 pub fn worker_id(worker: ResourceArc<WorkerRef>) -> NifResult<JsonSerdeWrap<WorkerId>> {
-    match worker.unwrap() {
-        Some(w) => Ok(JsonSerdeWrap::new(w.id())),
-        None => Err(Error::Term(Box::new(atoms::terminated()))),
-    }
+    let worker = worker.get_resource()?;
+
+    Ok(JsonSerdeWrap::new(worker.id()))
 }
 #[rustler::nif]
 pub fn worker_close(worker: ResourceArc<WorkerRef>) -> NifResult<(rustler::Atom,)> {
@@ -50,9 +49,7 @@ pub fn worker_create_router(
     worker: ResourceArc<WorkerRef>,
     option: SerRouterOptions,
 ) -> NifResult<(rustler::Atom, RouterStruct)> {
-    let worker = worker
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let worker = worker.get_resource()?;
 
     let option = option.to_option()?;
 
@@ -66,9 +63,7 @@ pub fn worker_create_router(
 
 #[rustler::nif]
 pub fn worker_dump(worker: ResourceArc<WorkerRef>) -> NifResult<JsonSerdeWrap<WorkerDump>> {
-    let worker = worker
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let worker = worker.get_resource()?;
 
     let dump = future::block_on(async move {
         return worker.dump().await;
@@ -79,9 +74,7 @@ pub fn worker_dump(worker: ResourceArc<WorkerRef>) -> NifResult<JsonSerdeWrap<Wo
 }
 #[rustler::nif]
 pub fn worker_closed(worker: ResourceArc<WorkerRef>) -> Result<bool, Error> {
-    let worker = worker
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let worker = worker.get_resource()?;
 
     Ok(worker.closed())
 }
@@ -90,9 +83,7 @@ pub fn worker_update_settings(
     worker: ResourceArc<WorkerRef>,
     settings: SerWorkerUpdateSettings,
 ) -> NifResult<(rustler::Atom,)> {
-    let worker = worker
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let worker = worker.get_resource()?;
 
     let settings = settings.to_setting()?;
 
@@ -109,9 +100,7 @@ pub fn worker_event(
     worker: ResourceArc<WorkerRef>,
     pid: rustler::LocalPid,
 ) -> NifResult<(rustler::Atom,)> {
-    let worker = worker
-        .unwrap()
-        .ok_or_else(|| Error::Term(Box::new(atoms::terminated())))?;
+    let worker = worker.get_resource()?;
 
     /* TODO: Can not create multiple instance for disposable
     {


### PR DESCRIPTION
RwLockが失敗した場合panicしてたところを
atom::poison_error
返すようにしました。

https://github.com/oviceinc/mediasoup-elixir/compare/refactor/remove_unwrap?expand=1#diff-8da4204d8ed3a96028d873ff9bad2d73eb885d5fbdc1a3d414fb4c7f42ec64c1R51
