### PR TITLE
chore: exclude nif.ex from coverage

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,7 @@ defmodule MediasoupElixir.MixProject do
       test_coverage: [
         tool: LcovEx,
         output: "coverage",
-        ignore_paths: ["test/"]
+        ignore_paths: ["test/", "lib/nif.ex"]
       ],
       dialyzer: [
         plt_add_apps: [:mix, :ex_unit],


### PR DESCRIPTION
nif.exは正常にライブラリがロードされたら通らない関数ばかりなのでcoverageの集計から除外。