### PR TITLE
Refactor/pattern match

### DIFF
--- a/lib/consumer.ex
+++ b/lib/consumer.ex
@@ -21,87 +21,87 @@ defmodule Mediasoup.Consumer do
   @type type :: String.t()
 
   @spec close(t) :: {:ok} | {:error}
-  def close(consumer) do
-    Nif.consumer_close(consumer.reference)
+  def close(%Consumer{reference: reference}) do
+    Nif.consumer_close(reference)
   end
 
   @spec dump(t) :: map | {:error}
-  def dump(consumer) do
-    Nif.consumer_dump(consumer.reference)
+  def dump(%Consumer{reference: reference}) do
+    Nif.consumer_dump(reference)
   end
 
   @spec closed?(t) :: boolean
-  def closed?(consumer) do
-    Nif.consumer_closed(consumer.reference)
+  def closed?(%Consumer{reference: reference}) do
+    Nif.consumer_closed(reference)
   end
 
   @spec paused?(t) :: boolean
-  def paused?(consumer) do
-    Nif.consumer_paused(consumer.reference)
+  def paused?(%Consumer{reference: reference}) do
+    Nif.consumer_paused(reference)
   end
 
   @spec producer_paused?(t) :: boolean
-  def producer_paused?(consumer) do
-    Nif.consumer_producer_paused(consumer.reference)
+  def producer_paused?(%Consumer{reference: reference}) do
+    Nif.consumer_producer_paused(reference)
   end
 
   @spec priority(t) :: number
-  def priority(consumer) do
-    Nif.consumer_priority(consumer.reference)
+  def priority(%Consumer{reference: reference}) do
+    Nif.consumer_priority(reference)
   end
 
   @spec score(t) :: map
-  def score(consumer) do
-    Nif.consumer_score(consumer.reference)
+  def score(%Consumer{reference: reference}) do
+    Nif.consumer_score(reference)
   end
 
   @spec preferred_layers(t) :: any
-  def preferred_layers(consumer) do
-    Nif.consumer_preferred_layers(consumer.reference)
+  def preferred_layers(%Consumer{reference: reference}) do
+    Nif.consumer_preferred_layers(reference)
   end
 
   @spec current_layers(t) :: any
-  def current_layers(consumer) do
-    Nif.consumer_current_layers(consumer.reference)
+  def current_layers(%Consumer{reference: reference}) do
+    Nif.consumer_current_layers(reference)
   end
 
   @spec get_stats(t) :: any
-  def get_stats(consumer) do
-    Nif.consumer_get_stats(consumer.reference)
+  def get_stats(%Consumer{reference: reference}) do
+    Nif.consumer_get_stats(reference)
   end
 
   @spec pause(t) :: {:ok} | {:error}
-  def pause(consumer) do
-    Nif.consumer_pause(consumer.reference)
+  def pause(%Consumer{reference: reference}) do
+    Nif.consumer_pause(reference)
   end
 
   @spec resume(t) :: {:ok} | {:error}
-  def resume(consumer) do
-    Nif.consumer_resume(consumer.reference)
+  def resume(%Consumer{reference: reference}) do
+    Nif.consumer_resume(reference)
   end
 
   @spec set_preferred_layers(t, map) :: {:ok} | {:error}
-  def set_preferred_layers(consumer, layer) do
-    Nif.consumer_set_preferred_layers(consumer.reference, layer)
+  def set_preferred_layers(%Consumer{reference: reference}, layer) do
+    Nif.consumer_set_preferred_layers(reference, layer)
   end
 
   @spec set_priority(t, integer) :: {:ok} | {:error}
-  def set_priority(consumer, priority) do
-    Nif.consumer_set_priority(consumer.reference, priority)
+  def set_priority(%Consumer{reference: reference}, priority) do
+    Nif.consumer_set_priority(reference, priority)
   end
 
   @spec unset_priority(t) :: {:ok} | {:error}
-  def unset_priority(consumer) do
-    Nif.consumer_unset_priority(consumer.reference)
+  def unset_priority(%Consumer{reference: reference}) do
+    Nif.consumer_unset_priority(reference)
   end
 
   @spec request_key_frame(t) :: {:ok} | {:error}
-  def request_key_frame(consumer) do
-    Nif.consumer_request_key_frame(consumer.reference)
+  def request_key_frame(%Consumer{reference: reference}) do
+    Nif.consumer_request_key_frame(reference)
   end
 
   @spec event(t, pid) :: {:ok} | {:error}
-  def event(consumer, pid) do
-    Nif.consumer_event(consumer.reference, pid)
+  def event(%Consumer{reference: reference}, pid) do
+    Nif.consumer_event(reference, pid)
   end
 end

--- a/lib/producer.ex
+++ b/lib/producer.ex
@@ -20,47 +20,47 @@ defmodule Mediasoup.Producer do
   @type type :: String.t()
 
   @spec close(t) :: {:ok} | {:error}
-  def close(producer) do
-    Nif.producer_close(producer.reference)
+  def close(%Producer{reference: reference}) do
+    Nif.producer_close(reference)
   end
 
   @spec dump(t) :: map
-  def dump(producer) do
-    Nif.producer_dump(producer.reference)
+  def dump(%Producer{reference: reference}) do
+    Nif.producer_dump(reference)
   end
 
   @spec pause(t) :: {:ok} | {:error}
-  def pause(producer) do
-    Nif.producer_pause(producer.reference)
+  def pause(%Producer{reference: reference}) do
+    Nif.producer_pause(reference)
   end
 
   @spec resume(t) :: {:ok} | {:error}
-  def resume(producer) do
-    Nif.producer_resume(producer.reference)
+  def resume(%Producer{reference: reference}) do
+    Nif.producer_resume(reference)
   end
 
   @spec score(t) :: list() | {:error}
-  def score(producer) do
-    Nif.producer_score(producer.reference)
+  def score(%Producer{reference: reference}) do
+    Nif.producer_score(reference)
   end
 
   @spec get_stats(t) :: list() | {:error}
-  def get_stats(producer) do
-    Nif.producer_get_stats(producer.reference)
+  def get_stats(%Producer{reference: reference}) do
+    Nif.producer_get_stats(reference)
   end
 
   @spec closed?(t) :: boolean()
-  def closed?(producer) do
-    Nif.producer_closed(producer.reference)
+  def closed?(%Producer{reference: reference}) do
+    Nif.producer_closed(reference)
   end
 
   @spec paused?(t) :: boolean() | {:error}
-  def paused?(producer) do
-    Nif.producer_paused(producer.reference)
+  def paused?(%Producer{reference: reference}) do
+    Nif.producer_paused(reference)
   end
 
   @spec event(t, pid) :: {:ok} | {:error}
-  def event(producer, pid) do
-    Nif.producer_event(producer.reference, pid)
+  def event(%Producer{reference: reference}, pid) do
+    Nif.producer_event(reference, pid)
   end
 end

--- a/lib/router.ex
+++ b/lib/router.ex
@@ -10,33 +10,33 @@ defmodule Mediasoup.Router do
   @type create_option :: map
 
   @spec close(t) :: {:ok} | {:error}
-  def close(router) do
-    Nif.router_close(router.reference)
+  def close(%Router{reference: reference}) do
+    Nif.router_close(reference)
   end
 
   @spec create_webrtc_transport(t, WebRtcTransport.create_option()) ::
           {:ok, WebRtcTransport.t()} | {:error, String.t()}
-  def create_webrtc_transport(router, option) do
-    Nif.router_create_webrtc_transport(router.reference, option)
+  def create_webrtc_transport(%Router{reference: reference}, option) do
+    Nif.router_create_webrtc_transport(reference, option)
   end
 
   @spec can_consume?(t, String.t(), rtpCapabilities) :: boolean
-  def can_consume?(router, producer_id, rtp_capabilities) do
-    Nif.router_can_consume(router.reference, producer_id, rtp_capabilities)
+  def can_consume?(%Router{reference: reference}, producer_id, rtp_capabilities) do
+    Nif.router_can_consume(reference, producer_id, rtp_capabilities)
   end
 
   @spec rtp_capabilities(t) :: Router.rtpCapabilities()
-  def rtp_capabilities(router) do
-    Nif.router_rtp_capabilities(router.reference)
+  def rtp_capabilities(%Router{reference: reference}) do
+    Nif.router_rtp_capabilities(reference)
   end
 
   @spec dump(t) :: map | {:error}
-  def dump(router) do
-    Nif.router_dump(router.reference)
+  def dump(%Router{reference: reference}) do
+    Nif.router_dump(reference)
   end
 
   @spec event(t, pid) :: {:ok} | {:error}
-  def event(router, pid) do
-    Nif.router_event(router.reference, pid)
+  def event(%Router{reference: reference}, pid) do
+    Nif.router_event(reference, pid)
   end
 end

--- a/lib/webrtc_transport.ex
+++ b/lib/webrtc_transport.ex
@@ -14,98 +14,98 @@ defmodule Mediasoup.WebRtcTransport do
   @type ice_parameter :: map()
 
   @spec close(t) :: {:ok} | {:error}
-  def close(transport) do
-    Nif.webrtc_transport_close(transport.reference)
+  def close(%WebRtcTransport{reference: reference}) do
+    Nif.webrtc_transport_close(reference)
   end
 
   @spec consume(t, consume_option()) :: {:ok, Consumer.t()} | {:error, String.t() | :terminated}
-  def consume(transport, option) do
-    Nif.webrtc_transport_consume(transport.reference, option)
+  def consume(%WebRtcTransport{reference: reference}, option) do
+    Nif.webrtc_transport_consume(reference, option)
   end
 
   @spec produce(t, produce_option()) :: {:ok, Producer.t()} | {:error, String.t() | :terminated}
-  def produce(transport, option) do
-    Nif.webrtc_transport_produce(transport.reference, option)
+  def produce(%WebRtcTransport{reference: reference}, option) do
+    Nif.webrtc_transport_produce(reference, option)
   end
 
   @spec connect(t, connect_option()) :: {:ok} | {:error, String.t() | :terminated}
-  def connect(transport, option) do
-    Nif.webrtc_transport_connect(transport.reference, option)
+  def connect(%WebRtcTransport{reference: reference}, option) do
+    Nif.webrtc_transport_connect(reference, option)
   end
 
   @spec ice_parameters(t) :: ice_parameter() | {:error, :terminated}
-  def ice_parameters(transport) do
-    Nif.webrtc_transport_ice_parameters(transport.reference)
+  def ice_parameters(%WebRtcTransport{reference: reference}) do
+    Nif.webrtc_transport_ice_parameters(reference)
   end
 
   @spec sctp_parameters(t) :: map() | {:error, :terminated}
-  def sctp_parameters(transport) do
-    Nif.webrtc_transport_sctp_parameters(transport.reference)
+  def sctp_parameters(%WebRtcTransport{reference: reference}) do
+    Nif.webrtc_transport_sctp_parameters(reference)
   end
 
   @spec ice_candidates(t) :: list(any)
-  def ice_candidates(transport) do
-    Nif.webrtc_transport_ice_candidates(transport.reference)
+  def ice_candidates(%WebRtcTransport{reference: reference}) do
+    Nif.webrtc_transport_ice_candidates(reference)
   end
 
   @spec ice_role(t) :: String.t() | {:error, :terminated}
-  def ice_role(transport) do
-    Nif.webrtc_transport_ice_role(transport.reference)
+  def ice_role(%WebRtcTransport{reference: reference}) do
+    Nif.webrtc_transport_ice_role(reference)
   end
 
   @spec set_max_incoming_bitrate(t, integer) :: {:ok} | {:error, :terminated}
-  def set_max_incoming_bitrate(transport, bitrate) do
-    Nif.webrtc_transport_set_max_incoming_bitrate(transport.reference, bitrate)
+  def set_max_incoming_bitrate(%WebRtcTransport{reference: reference}, bitrate) do
+    Nif.webrtc_transport_set_max_incoming_bitrate(reference, bitrate)
   end
 
   @spec set_max_outgoing_bitrate(t, integer) :: {:ok} | {:error, :terminated}
-  def set_max_outgoing_bitrate(transport, bitrate) do
-    Nif.webrtc_transport_set_max_outgoing_bitrate(transport.reference, bitrate)
+  def set_max_outgoing_bitrate(%WebRtcTransport{reference: reference}, bitrate) do
+    Nif.webrtc_transport_set_max_outgoing_bitrate(reference, bitrate)
   end
 
   @spec ice_state(t) :: String.t() | {:error, :terminated}
-  def ice_state(transport) do
-    Nif.webrtc_transport_ice_state(transport.reference)
+  def ice_state(%WebRtcTransport{reference: reference}) do
+    Nif.webrtc_transport_ice_state(reference)
   end
 
   @spec restart_ice(t) :: {:ok, ice_parameter} | {:error, :terminated}
-  def restart_ice(transport) do
-    Nif.webrtc_transport_restart_ice(transport.reference)
+  def restart_ice(%WebRtcTransport{reference: reference}) do
+    Nif.webrtc_transport_restart_ice(reference)
   end
 
   @spec ice_selected_tuple(t) :: String.t() | nil | {:error, :terminated}
-  def ice_selected_tuple(transport) do
-    Nif.webrtc_transport_ice_selected_tuple(transport.reference)
+  def ice_selected_tuple(%WebRtcTransport{reference: reference}) do
+    Nif.webrtc_transport_ice_selected_tuple(reference)
   end
 
   @spec dtls_parameters(t) :: map | {:error, :terminated}
-  def dtls_parameters(transport) do
-    Nif.webrtc_transport_dtls_parameters(transport.reference)
+  def dtls_parameters(%WebRtcTransport{reference: reference}) do
+    Nif.webrtc_transport_dtls_parameters(reference)
   end
 
   @spec dtls_state(t) :: String.t() | {:error, :terminated}
-  def dtls_state(transport) do
-    Nif.webrtc_transport_dtls_state(transport.reference)
+  def dtls_state(%WebRtcTransport{reference: reference}) do
+    Nif.webrtc_transport_dtls_state(reference)
   end
 
   @spec sctp_state(t) :: String.t() | {:error, :terminated}
-  def sctp_state(transport) do
-    Nif.webrtc_transport_sctp_state(transport.reference)
+  def sctp_state(%WebRtcTransport{reference: reference}) do
+    Nif.webrtc_transport_sctp_state(reference)
   end
 
   @type transport_stat :: map
   @spec get_stats(t) :: list(transport_stat) | {:error, :terminated}
-  def get_stats(transport) do
-    Nif.webrtc_transport_get_stats(transport.reference)
+  def get_stats(%WebRtcTransport{reference: reference}) do
+    Nif.webrtc_transport_get_stats(reference)
   end
 
   @spec dump(t) :: any | {:error, :terminated}
-  def dump(transport) do
-    Nif.webrtc_transport_dump(transport.reference)
+  def dump(%WebRtcTransport{reference: reference}) do
+    Nif.webrtc_transport_dump(reference)
   end
 
   @spec event(t, pid) :: {:ok} | {:error, :terminated}
-  def event(transport, pid) do
-    Nif.webrtc_transport_event(transport.reference, pid)
+  def event(%WebRtcTransport{reference: reference}, pid) do
+    Nif.webrtc_transport_event(reference, pid)
   end
 end

--- a/lib/worker.ex
+++ b/lib/worker.ex
@@ -35,32 +35,32 @@ defmodule Mediasoup.Worker do
         }
 
   @spec close(t) :: {:ok} | {:error}
-  def close(worker) do
-    Nif.worker_close(worker.reference)
+  def close(%Worker{reference: reference}) do
+    Nif.worker_close(reference)
   end
 
   @spec create_router(t, Router.create_option()) :: {:ok, Router.t()} | {:error}
-  def create_router(worker, option) do
-    Nif.worker_create_router(worker.reference, option)
+  def create_router(%Worker{reference: reference}, option) do
+    Nif.worker_create_router(reference, option)
   end
 
   @spec update_settings(t, update_option) :: {:ok} | {:error}
-  def update_settings(worker, pid) do
-    Nif.worker_update_settings(worker.reference, pid)
+  def update_settings(%Worker{reference: reference}, pid) do
+    Nif.worker_update_settings(reference, pid)
   end
 
   @spec closed?(t) :: boolean
-  def closed?(worker) do
-    Nif.worker_closed(worker.reference)
+  def closed?(%Worker{reference: reference}) do
+    Nif.worker_closed(reference)
   end
 
   @spec dump(t) :: map
-  def dump(worker) do
-    Nif.worker_dump(worker.reference)
+  def dump(%Worker{reference: reference}) do
+    Nif.worker_dump(reference)
   end
 
   @spec event(t, pid) :: {:ok} | {:error}
-  def event(worker, pid) do
-    Nif.worker_event(worker.reference, pid)
+  def event(%Worker{reference: reference}, pid) do
+    Nif.worker_event(reference, pid)
   end
 end


### PR DESCRIPTION
引数はpattern matchでTypespecsとは別で想定外の型を受け付けないようにしたほうが安全で読みやすい