### PR TITLE
chore(bump): Update mediasoup to 0.9.0

### DIFF
--- a/native/mediasoup_elixir/.cargo/config
+++ b/native/mediasoup_elixir/.cargo/config
@@ -1,4 +1,4 @@
-[target.x86_64-apple-darwin]
+[target.'cfg(target_os = "macos")']
 rustflags = [
     "-C", "link-arg=-undefined",
     "-C", "link-arg=dynamic_lookup",

--- a/native/mediasoup_elixir/Cargo.toml
+++ b/native/mediasoup_elixir/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 rustler = "0.22.0"
-mediasoup = "= 0.8.5"
+mediasoup = "= 0.9.0"
 futures-lite = "1.12.0"
 serde = { version = "1.0.130", features = ["derive"] }
 serde-transcode = "1.1"

--- a/native/mediasoup_elixir/src/producer.rs
+++ b/native/mediasoup_elixir/src/producer.rs
@@ -146,7 +146,7 @@ pub fn producer_event(
             .on_score(move |score| {
                 send_msg_from_other_thread(
                     pid.clone(),
-                    (atoms::on_score(), JsonSerdeWrap::new(score.clone())),
+                    (atoms::on_score(), JsonSerdeWrap::new(score.to_vec())),
                 );
             })
             .detach();


### PR DESCRIPTION
This version is possible to build with M1 mac. 🎉 
And contains some optimization. https://github.com/versatica/mediasoup/compare/rust-0.8.5...rust-0.9.0