### PR TITLE
feat: output mediasoup log

### DIFF
--- a/native/mediasoup_elixir/Cargo.toml
+++ b/native/mediasoup_elixir/Cargo.toml
@@ -21,5 +21,5 @@ serde = { version = "1.0.130", features = ["derive"] }
 serde-transcode = "1.1"
 serde_json = "1.0"
 serde_rustler = { path = "local_deps/serde_rustler/serde_rustler" }
-
+env_logger = "0.9.0"
 

--- a/native/mediasoup_elixir/src/lib.rs
+++ b/native/mediasoup_elixir/src/lib.rs
@@ -205,6 +205,8 @@ rustler::init! {
 }
 
 fn on_load<'a>(env: Env<'a>, _load_info: Term<'a>) -> bool {
+    env_logger::init();
+
     // This macro will take care of defining and initializing a new resource
     // object type.
     rustler::resource!(WorkerRef, env);

--- a/test/integration/test_pipe_transport.ex
+++ b/test/integration/test_pipe_transport.ex
@@ -506,6 +506,11 @@ defmodule IntegrateTest.PipeTransportTest do
     assert match?(%{}, srtp_parameters)
     assert String.length(srtp_parameters["keyBase64"]) == 40
 
+    Mediasoup.Worker.update_settings(worker, %Mediasoup.Worker.UpdateableSettings{
+      log_level: :none,
+      log_tags: []
+    })
+
     # Missing srtp_parameters.
     {:error, _message} =
       PipeTransport.connect(pipe_transport, %{ip: "127.0.0.2", port: 9999, srtpParameters: nil})
@@ -529,6 +534,11 @@ defmodule IntegrateTest.PipeTransportTest do
       Router.create_pipe_transport(router1, %PipeTransport.Options{
         listen_ip: %{ip: "127.0.0.1"}
       })
+
+    Mediasoup.Worker.update_settings(worker, %Mediasoup.Worker.UpdateableSettings{
+      log_level: :none,
+      log_tags: []
+    })
 
     # No SRTP enabled so passing srtp_parameters must fail.
     {:error, _message} =
@@ -663,7 +673,8 @@ defmodule IntegrateTest.PipeTransportTest do
             ip: "127.0.0.1"
           }
         },
-        enable_sctp: true
+        enable_sctp: true,
+        enable_srtp: true
       })
 
     {:ok, transport2} =

--- a/test/integration/test_producer.ex
+++ b/test/integration/test_producer.ex
@@ -234,6 +234,11 @@ defmodule IntegrateTest.ProducerTest do
   def produce_wrong_arguments(worker) do
     {_worker, _router, transport_1, _transport_2} = init(worker)
 
+    Mediasoup.Worker.update_settings(worker, %Mediasoup.Worker.UpdateableSettings{
+      log_level: :none,
+      log_tags: []
+    })
+
     # Empty rtp_parameters.codecs.
     {:error, message} =
       WebRtcTransport.produce(transport_1, %{
@@ -352,6 +357,11 @@ defmodule IntegrateTest.ProducerTest do
 
     {:ok, _first_producer} = WebRtcTransport.produce(transport_1, audio_producer_options())
 
+    Mediasoup.Worker.update_settings(worker, %Mediasoup.Worker.UpdateableSettings{
+      log_level: :none,
+      log_tags: []
+    })
+
     {:error, message} =
       WebRtcTransport.produce(transport_1, %{
         kind: "audio",
@@ -427,6 +437,11 @@ defmodule IntegrateTest.ProducerTest do
 
   def produce_no_mid_single_encoding_without_dir_or_ssrc(worker) do
     {_worker, _router, transport_1, _transport_2} = init(worker)
+
+    Mediasoup.Worker.update_settings(worker, %Mediasoup.Worker.UpdateableSettings{
+      log_level: :none,
+      log_tags: []
+    })
 
     {:error, message} =
       WebRtcTransport.produce(transport_1, %{

--- a/test/integration/test_webrtc_transport.ex
+++ b/test/integration/test_webrtc_transport.ex
@@ -200,6 +200,11 @@ defmodule IntegrateTest.WebRtcTransportTest do
   def create_non_bindable_ip(worker) do
     {_worker, router} = init(worker)
 
+    Mediasoup.Worker.update_settings(worker, %Mediasoup.Worker.UpdateableSettings{
+      log_level: :none,
+      log_tags: []
+    })
+
     {:error, _message} =
       Router.create_webrtc_transport(router, %{
         listenIps: {
@@ -290,6 +295,11 @@ defmodule IntegrateTest.WebRtcTransportTest do
       WebRtcTransport.connect(transport, %{
         dtlsParameters: dtls_parameters
       })
+
+    Mediasoup.Worker.update_settings(worker, %Mediasoup.Worker.UpdateableSettings{
+      log_level: :none,
+      log_tags: []
+    })
 
     # Must fail if connected.
     {:error, _error} =


### PR DESCRIPTION
Output mediasoup log with `env_logger::init()`
https://teaclave.apache.org/api-docs/crates-app/env_logger/fn.init.html