### PR TITLE
fix: Can not use error atom for log_level

### DIFF
--- a/native/mediasoup_elixir/src/worker.rs
+++ b/native/mediasoup_elixir/src/worker.rs
@@ -86,6 +86,7 @@ pub fn worker_event(
     let worker = worker.get_resource()?;
 
     /* TODO: Can not create multiple instance for disposable
+    If we need this, implement at elixir side.
     {
         let pid = pid.clone();
         worker
@@ -153,7 +154,7 @@ impl WorkerUpdateableSettingsStruct {
         let mut value = WorkerUpdateSettings::default();
 
         if let Some(log_level) = &self.log_level {
-            value.log_level = Some(log_level_from_string(log_level.as_str())?)
+            value.log_level = Some(log_level_from_string(log_level)?)
         }
         if let Some(log_tags) = &self.log_tags {
             value.log_tags = Some(log_tags_from_strings(log_tags)?)
@@ -177,7 +178,7 @@ impl WorkerSettingsStruct {
     fn try_to_setting(&self) -> Result<WorkerSettings, Error> {
         let mut value = WorkerSettings::default();
         if let Some(log_level) = &self.log_level {
-            value.log_level = log_level_from_string(log_level.as_str())?
+            value.log_level = log_level_from_string(log_level)?
         }
         if let Some(log_tags) = &self.log_tags {
             value.log_tags = log_tags_from_strings(log_tags)?
@@ -204,6 +205,7 @@ fn log_level_from_string(s: &str) -> NifResult<WorkerLogLevel> {
     return match s {
         "debug" => Ok(WorkerLogLevel::Debug),
         "error" => Ok(WorkerLogLevel::Error),
+        "Err" => Ok(WorkerLogLevel::Error), // workaround for :error to "Err" by serde
         "none" => Ok(WorkerLogLevel::None),
         "warn" => Ok(WorkerLogLevel::Warn),
         _ => Err(Error::RaiseTerm(Box::new(format!(

--- a/test/router_test.exs
+++ b/test/router_test.exs
@@ -5,7 +5,7 @@ defmodule RouterTest do
     settings = %{
       rtcMinPort: 10000,
       rtcMaxPort: 10010,
-      logLevel: :debug
+      logLevel: :error
     }
 
     {:ok, worker} = Mediasoup.Worker.start_link(settings: settings)

--- a/test/webrtc_transport_test.exs
+++ b/test/webrtc_transport_test.exs
@@ -47,6 +47,10 @@ defmodule MediasoupElixirWebRtcTransportTest do
   end
 
   test "close_router_event", %{worker: worker} do
-    IntegrateTest.PipeTransportTest.close_router_event(worker)
+    IntegrateTest.WebRtcTransportTest.close_router_event(worker)
+  end
+
+  test "create_many_webrtc_transport" do
+    IntegrateTest.WebRtcTransportTest.create_many_webrtc_transport()
   end
 end


### PR DESCRIPTION
Because `:error` atom convert to `"Err"` string by rustler_serde