### PR TITLE
chore: update dependency packages

### DIFF
--- a/Dockerfile_dev
+++ b/Dockerfile_dev
@@ -9,7 +9,10 @@ RUN set -ex && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         gcc \
+        g++ \
+        make \
         libc6-dev \
+        python3-pip \
         wget && \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- \
       -y --profile minimal --default-toolchain $RUST_VERSION -c component add rustfmt clippy

--- a/README.md
+++ b/README.md
@@ -4,5 +4,4 @@
 ## Installation
 ### Requirement
   * [Rust](https://www.rust-lang.org/)
-  * `make` and `c/c++ compilers` for build for mediasoup
-
+  * `make`, `python3-pip` and `c/c++ compilers` for build for mediasoup


### PR DESCRIPTION
## Context
`$ mix compile` fails.

```
error: failed to run custom build command for `mediasoup-sys v0.3.1`

Caused by:
  process didn't exit successfully: `/var/opt/app/_build/dev/lib/mediasoup_elixir/native/mediasoup_elixir/debug/build/mediasoup-sys-39338bc86185d4bb/build-script-build` (exit status: 101)
  --- stdout
  cargo:rustc-link-search=native=/usr/lib/gcc/x86_64-linux-gnu/8/
  cargo:rustc-link-lib=static=stdc++
  # Updated pip and setuptools are needed for meson
  # `--system` is not present everywhere and is only needed as workaround for
  # Debian-specific issue (copied from
  # https://github.com/gluster/gstatus/pull/33), fallback to command without
  # `--system` if the first one fails.
  /usr/bin/python3 -m pip install --system --target=/var/opt/app/_build/dev/lib/mediasoup_elixir/native/mediasoup_elixir/debug/build/mediasoup-sys-33ea4e6544a53a37/out/out/pip pip setuptools || \
        /usr/bin/python3 -m pip install --target=/var/opt/app/_build/dev/lib/mediasoup_elixir/native/mediasoup_elixir/debug/build/mediasoup-sys-33ea4e6544a53a37/out/out/pip pip setuptools || \
        echo "Installation failed, likely because PIP is unavailable, if you are on Debian/Ubuntu or derivative please install the python3-pip package"
  Installation failed, likely because PIP is unavailable, if you are on Debian/Ubuntu or derivative please install the python3-pip package
  # Install `meson` and `ninja` using `pip` into custom location, so we don't
  # depend on system-wide installation.
  /usr/bin/python3 -m pip install --upgrade --target=/var/opt/app/_build/dev/lib/mediasoup_elixir/native/mediasoup_elixir/debug/build/mediasoup-sys-33ea4e6544a53a37/out/out/pip  meson ninja

  --- stderr
  /usr/bin/python3: No module named pip
  /usr/bin/python3: No module named pip
  /usr/bin/python3: No module named pip
  make: *** [Makefile:64: meson-ninja] Error 1
  thread 'main' panicked at 'Failed to build libmediasoup-worker', /root/.cargo/registry/src/github.com-1ecc6299db9ec823/mediasoup-sys-0.3.1/build.rs:94:9
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
error: build failed

== Compilation error in file lib/nif.ex ==
** (RuntimeError) Rust NIF compile error (rustc exit code 101)
    (rustler 0.23.0) lib/rustler/compiler.ex:40: Rustler.Compiler.compile_crate/2
    lib/nif.ex:6: (module)
    (stdlib 3.15) erl_eval.erl:685: :erl_eval.do_apply/6
```