### PR TITLE
fix to pass "mix compile"

### DIFF
--- a/native/mediasoup_elixir/Cargo.toml
+++ b/native/mediasoup_elixir/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 [dependencies]
 rustler = "0.23.0"
 # Workaround for build error. When this https://github.com/versatica/mediasoup/issues/754 issue fixed, use the upstream repository or cargo package.
-mediasoup = { git = "https://github.com/versatica/mediasoup.git", rev ="55c6015e98cf7da5e56ead511a8fb34df6ba48a4" }
+mediasoup = "0.9.2"
 futures-lite = "1.12.0"
 once_cell = "1.9.0"
 num_cpus = "1.13.1"


### PR DESCRIPTION
## Context

in current main branch, `$ mix compile` fails in my docker container as follows

<details>
<summary> show error log </summary>

```
Compiling crate mediasoup_elixir in debug mode (native/mediasoup_elixir)
   Compiling mediasoup-sys v0.3.1 (https://github.com/satoren/mediasoup.git?rev=9777128e5ba9a587cbf1768ea73769b81f582409#9777128e)
error: failed to run custom build command for `mediasoup-sys v0.3.1 (https://github.com/satoren/mediasoup.git?rev=9777128e5ba9a587cbf1768ea73769b81f582409#9777128e)`

Caused by:
  process didn't exit successfully: `/var/opt/app/_build/dev/lib/mediasoup_elixir/native/mediasoup_elixir/debug/build/mediasoup-sys-db22bb79012b67b9/build-script-build` (exit status: 101)
  --- stdout
  cargo:rustc-link-search=native=/usr/lib/gcc/x86_64-linux-gnu/8/
  cargo:rustc-link-lib=static=stdc++
  # Updated pip and setuptools are needed for meson
  # `--system` is not present everywhere and is only needed as workaround for
  # Debian-specific issue (copied from
  # https://github.com/gluster/gstatus/pull/33), fallback to command without
  # `--system` if the first one fails.
  /usr/bin/python3 -m pip install --system --target=/var/opt/app/_build/dev/lib/mediasoup_elixir/native/mediasoup_elixir/debug/build/mediasoup-sys-ab88161877e2ceeb/out/out/pip pip setuptools || \
        /usr/bin/python3 -m pip install --target=/var/opt/app/_build/dev/lib/mediasoup_elixir/native/mediasoup_elixir/debug/build/mediasoup-sys-ab88161877e2ceeb/out/out/pip pip setuptools || \
        echo "Installation failed, likely because PIP is unavailable, if you are on Debian/Ubuntu or derivative please install the python3-pip package"
  Collecting pip
    Downloading https://files.pythonhosted.org/packages/a4/6d/6463d49a933f547439d6b5b98b46af8742cc03ae83543e4d7688c2420f8b/pip-21.3.1-py3-none-any.whl (1.7MB)
  Collecting setuptools
    Downloading https://files.pythonhosted.org/packages/eb/53/0dd4c7960579da8be13fa9b2c2591643d37f323e3d79f8bc8b1b6c8e6217/setuptools-60.5.0-py3-none-any.whl (958kB)
  Installing collected packages: pip, setuptools
  Successfully installed pip-21.3.1 setuptools-60.5.0
  # Install `meson` and `ninja` using `pip` into custom location, so we don't
  # depend on system-wide installation.
  /usr/bin/python3 -m pip install --upgrade --target=/var/opt/app/_build/dev/lib/mediasoup_elixir/native/mediasoup_elixir/debug/build/mediasoup-sys-ab88161877e2ceeb/out/out/pip  meson==0.60.3 ninja
  Collecting meson==0.60.3
    Downloading meson-0.60.3-py3-none-any.whl (838 kB)
  Collecting ninja
    Downloading ninja-1.10.2.3-py2.py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.whl (108 kB)
  Installing collected packages: ninja, meson
  Successfully installed meson-0.60.3 ninja-1.10.2.3
  /var/opt/app/_build/dev/lib/mediasoup_elixir/native/mediasoup_elixir/debug/build/mediasoup-sys-ab88161877e2ceeb/out/out/pip/bin/meson setup \
        --buildtype debug \
        -Db_pie=true \
        -Db_staticpic=true \
        --reconfigure \
        "" \
        /var/opt/app/_build/dev/lib/mediasoup_elixir/native/mediasoup_elixir/debug/build/mediasoup-sys-ab88161877e2ceeb/out/out/Debug/build || \
        /var/opt/app/_build/dev/lib/mediasoup_elixir/native/mediasoup_elixir/debug/build/mediasoup-sys-ab88161877e2ceeb/out/out/pip/bin/meson setup \
                --buildtype debug \
                -Db_pie=true \
                -Db_staticpic=true \
                "" \
                /var/opt/app/_build/dev/lib/mediasoup_elixir/native/mediasoup_elixir/debug/build/mediasoup-sys-ab88161877e2ceeb/out/out/Debug/build
  The Meson build system
  Version: 0.60.3
  Source dir: /root/.cargo/git/checkouts/mediasoup-86965fc04d523140/9777128/worker
  Build dir: /var/opt/app/_build/dev/lib/mediasoup_elixir/native/mediasoup_elixir/debug/build/mediasoup-sys-ab88161877e2ceeb/out/out/Debug/build
  Build type: native build
  Project name: mediasoup-worker
  Project version: undefined
  C compiler for the host machine: cc (gcc 8.3.0 "cc (Debian 8.3.0-6) 8.3.0")
  C linker for the host machine: cc ld.bfd 2.31.1
  C++ compiler for the host machine: c++ (gcc 8.3.0 "c++ (Debian 8.3.0-6) 8.3.0")
  C++ linker for the host machine: c++ ld.bfd 2.31.1
  Host machine cpu family: x86_64
  Host machine cpu: x86_64
  Downloading openssl source from https://www.openssl.org/source/openssl-1.1.1l.tar.gz
  Download size: 9834044
  Downloading: ..........
  Downloading openssl patch from https://wrapdb.mesonbuild.com/v2/openssl_1.1.1l-2/get_patch
  Download size: 10613607
  Downloading:
  A fallback URL could be specified using patch_fallback_url key in the wrap file

  meson.build:147:0: ERROR: Incorrect hash for patch:
   852521fb016fa2deee8ebf9ffeeee0292c6de86a03c775cf72ac04e86f9f177e expected
   7b1badb55232faf35b74fe502b8d2d5b90c54c585c28c4df5cbeb8a299779d9d actual.

  A full log can be found at /var/opt/app/_build/dev/lib/mediasoup_elixir/native/mediasoup_elixir/debug/build/mediasoup-sys-ab88161877e2ceeb/out/out/Debug/build/meson-logs/meson-log.txt

  --- stderr
  WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
  Directory does not contain a valid build tree:
  /var/opt/app/_build/dev/lib/mediasoup_elixir/native/mediasoup_elixir/debug/build/mediasoup-sys-ab88161877e2ceeb/out/out/Debug/build
  make: *** [Makefile:90: setup] Error 1
  thread 'main' panicked at 'Failed to build libmediasoup-worker', /root/.cargo/git/checkouts/mediasoup-86965fc04d523140/9777128/worker/build.rs:94:9
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

== Compilation error in file lib/nif.ex ==
** (RuntimeError) Rust NIF compile error (rustc exit code 101)
    (rustler 0.23.0) lib/rustler/compiler.ex:40: Rustler.Compiler.compile_crate/2
    lib/nif.ex:6: (module)
    (stdlib 3.15) erl_eval.erl:685: :erl_eval.do_apply/6
```

</details>

after pointing `mediasoup = "0.9.2"`, the new version (v0.3.2) of `mediasoup-sys` is installed that includes https://github.com/versatica/mediasoup/pull/755, it works well
```
$ mix compile
Compiling 11 files (.ex)
    Updating git repository `https://github.com/versatica/mediasoup.git`
Compiling crate mediasoup_elixir in debug mode (native/mediasoup_elixir)
   Compiling mediasoup-sys v0.3.2 (https://github.com/versatica/mediasoup.git?rev=55c6015e98cf7da5e56ead511a8fb34df6ba48a4#55c6015e)
Compiling lib/nif.ex (it's taking more than 10s)
   Compiling mediasoup v0.9.2 (https://github.com/versatica/mediasoup.git?rev=55c6015e98cf7da5e56ead511a8fb34df6ba48a4#55c6015e)
   Compiling mediasoup_elixir v0.3.3 (/var/opt/app/native/mediasoup_elixir)
    Finished dev [unoptimized + debuginfo] target(s) in 1m 29s
Generated mediasoup_elixir app
```