### PR TITLE
update mediasoup rust version to 0.9.3

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule MediasoupElixir.MixProject do
   def project do
     [
       app: :mediasoup_elixir,
-      version: "0.3.4",
+      version: "0.3.5",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/native/mediasoup_elixir/Cargo.toml
+++ b/native/mediasoup_elixir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mediasoup_elixir"
-version = "0.3.4"
+version = "0.3.5"
 authors = []
 edition = "2018"
 
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 [dependencies]
 rustler = "0.23.0"
 # Workaround for thread leak by deadlock. When this https://github.com/versatica/mediasoup/issues/728#issuecomment-1078689590 issue fixed, use the upstream repository or cargo package.
-mediasoup = { git = "https://github.com/satoren/mediasoup.git", rev ="eeed4a89c45a15d3785280609bc26de2a216884a" }
+mediasoup = "0.9.3"
 futures-lite = "1.12.0"
 once_cell = "1.9.0"
 num_cpus = "1.13.1"


### PR DESCRIPTION
My patch did not fully fix the deadlock. So we will use the new version mediasoup-rust with more extensive and appropriate modifications

https://github.com/versatica/mediasoup/blob/v3/rust/CHANGELOG.md#093


The following is a stack trace in a production env
<details>

```
#0  syscall () at ../sysdeps/unix/sysv/linux/aarch64/syscall.S:38
#1  0x0000fffe26150a64 in parking_lot::raw_mutex::RawMutex::lock_slow () from /opt/ovice_ex_core/ovice_ex_core/lib/mediasoup_elixir-0.3.4/priv/native/libmediasoup_elixir.so
#2  0x0000fffe2633f4dc in core::ops::function::FnOnce::call_once{{vtable-shim}} ()
   from /opt/ovice_ex_core/ovice_ex_core/lib/mediasoup_elixir-0.3.4/priv/native/libmediasoup_elixir.so
#3  0x0000fffe262f94f8 in <alloc::vec::Vec<T,A> as core::ops::drop::Drop>::drop ()
   from /opt/ovice_ex_core/ovice_ex_core/lib/mediasoup_elixir-0.3.4/priv/native/libmediasoup_elixir.so
#4  0x0000fffe262e9f34 in <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll ()
   from /opt/ovice_ex_core/ovice_ex_core/lib/mediasoup_elixir-0.3.4/priv/native/libmediasoup_elixir.so
#5  0x0000fffe263a56c8 in async_task::raw::RawTask<F,T,S>::run () from /opt/ovice_ex_core/ovice_ex_core/lib/mediasoup_elixir-0.3.4/priv/native/libmediasoup_elixir.so
#6  0x0000fffe262eec2c in <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll ()
   from /opt/ovice_ex_core/ovice_ex_core/lib/mediasoup_elixir-0.3.4/priv/native/libmediasoup_elixir.so
#7  0x0000fffe262e8900 in <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll ()
   from /opt/ovice_ex_core/ovice_ex_core/lib/mediasoup_elixir-0.3.4/priv/native/libmediasoup_elixir.so
#8  0x0000fffe262fc7f0 in futures_lite::future::block_on () from /opt/ovice_ex_core/ovice_ex_core/lib/mediasoup_elixir-0.3.4/priv/native/libmediasoup_elixir.so
#9  0x0000fffe2639227c in std::sys_common::backtrace::__rust_begin_short_backtrace ()
   from /opt/ovice_ex_core/ovice_ex_core/lib/mediasoup_elixir-0.3.4/priv/native/libmediasoup_elixir.so
#10 0x0000fffe2638644c in core::ops::function::FnOnce::call_once{{vtable-shim}} ()
   from /opt/ovice_ex_core/ovice_ex_core/lib/mediasoup_elixir-0.3.4/priv/native/libmediasoup_elixir.so
#11 0x0000fffe268066a0 in <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once ()
    at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/alloc/src/boxed.rs:1575
#12 <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once () at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/alloc/src/boxed.rs:1575
#13 std::sys::unix::thread::Thread::new::thread_start () at library/std/src/sys/unix/thread.rs:71
#14 0x0000ffffac2f13f0 in start_thread (arg=0xfffe1cbaed4f) at pthread_create.c:477
#15 0x0000ffffac2490dc in thread_start () at ../sysdeps/unix/sysv/linux/aarch64/clone.S:78

#0  syscall () at ../sysdeps/unix/sysv/linux/aarch64/syscall.S:38
#1  0x0000fffe26801b74 in std::sys::unix::futex::futex_wait () at library/std/src/sys/unix/futex.rs:25
#2  std::sys_common::thread_parker::futex::Parker::park () at library/std/src/sys_common/thread_parker/futex.rs:50
#3  std::thread::park () at library/std/src/thread/mod.rs:901
#4  std::sync::mpsc::blocking::WaitToken::wait () at library/std/src/sync/mpsc/blocking.rs:68
#5  0x0000fffe2634f994 in std::sync::mpsc::oneshot::Packet<T>::recv () at library/std/src/panicking.rs:541
#6  0x0000fffe262d848c in std::sync::mpsc::Receiver<T>::recv () at library/std/src/panicking.rs:541
#7  0x0000fffe2638c5e8 in <mediasoup::worker_manager::Inner as core::ops::drop::Drop>::drop () at library/std/src/panicking.rs:541
#8  0x0000fffe2630e9b8 in alloc::sync::Arc<T>::drop_slow () at library/std/src/panicking.rs:541
#9  0x0000fffe263114f8 in alloc::sync::Arc<T>::drop_slow () at library/std/src/panicking.rs:541
#10 0x0000fffe2631089c in alloc::sync::Arc<T>::drop_slow () at library/std/src/panicking.rs:541
#11 0x0000fffe2630cf20 in alloc::sync::Arc<T>::drop_slow () at library/std/src/panicking.rs:541
#12 0x0000fffe26311e2c in alloc::sync::Arc<T>::drop_slow () at library/std/src/panicking.rs:541
#13 0x0000fffe262c180c in mediasoup::router::consumer::Consumer::new::{{closure}} () at library/std/src/panicking.rs:541
#14 0x0000fffe26344db4 in mediasoup::worker::common::EventHandlers$LT$alloc..sync..Arc$LT$dyn$u20$core..ops..function..Fn$LT$$LP$$RF$V$C$$RP$$GT$$u2b$Output$u20$$u3d$$u20$$LP$$RP$$u2b$core..marker..Sync$u2b$core..marker..Send$GT$$GT$::call_callbacks_with_single_value::h704fffc91b8d315b () at library/std/src/panicking.rs:541
#15 0x0000fffe263442ec in mediasoup::worker::channel::Channel::new::{{closure}} () at library/std/src/panicking.rs:541
#16 0x0000fffe263cf218 in Channel::ChannelSocket::Send(nlohmann::basic_json<std::map, std::vector, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, long, unsigned long, double, std::allocator, nlohmann::adl_serializer, std::vector<unsigned char, std::allocator<unsigned char> > >&) ()
    at library/std/src/panicking.rs:541
#17 0x0000fffe263caf44 in Channel::ChannelNotifier::Emit(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, char const*) ()
    at library/std/src/panicking.rs:541
#18 0x0000fffe265e5bf0 in RTC::Consumer::ProducerClosed() () at library/std/src/panicking.rs:541
#19 0x0000fffe263fdf44 in RTC::Router::OnTransportProducerClosed(RTC::Transport*, RTC::Producer*) () at library/std/src/panicking.rs:541
#20 0x0000fffe264188cc in RTC::Transport::HandleRequest(Channel::ChannelRequest*) () at library/std/src/panicking.rs:541
#21 0x0000fffe2642b3b0 in RTC::WebRtcTransport::HandleRequest(Channel::ChannelRequest*) () at library/std/src/panicking.rs:541
#22 0x0000fffe263f5bcc in RTC::Router::HandleRequest(Channel::ChannelRequest*) () at library/std/src/panicking.rs:541
#23 0x0000fffe263c8158 in Worker::OnChannelRequest(Channel::ChannelSocket*, Channel::ChannelRequest*) () at library/std/src/panicking.rs:541
#24 0x0000fffe263cf4e4 in Channel::ChannelSocket::CallbackRead() () at library/std/src/panicking.rs:541
#25 0x0000fffe263cf890 in Channel::onAsync(uv_handle_s*) () at library/std/src/panicking.rs:541
#26 0x0000fffe2651a2d4 in uv.async_io () at library/std/src/panicking.rs:541
#27 0x0000fffe26527894 in uv.io_poll () at library/std/src/panicking.rs:541
#28 0x0000fffe2651aaf8 in uv_run () at library/std/src/panicking.rs:541
#29 0x0000fffe263b92cc in DepLibUV::RunLoop() () at library/std/src/panicking.rs:541
#30 0x0000fffe263c2444 in Worker::Worker(Channel::ChannelSocket*, PayloadChannel::PayloadChannelSocket*) () at library/std/src/panicking.rs:541
#31 0x0000fffe263b7b98 in mediasoup_worker_run () at library/std/src/panicking.rs:541
#32 0x0000fffe261bdebc in std::sys_common::backtrace::__rust_begin_short_backtrace () at library/std/src/panicking.rs:541
#33 0x0000fffe2623c780 in core::ops::function::FnOnce::call_once{{vtable-shim}} () at library/std/src/panicking.rs:541
#34 0x0000fffe268066a0 in <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once ()
    at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/alloc/src/boxed.rs:1575
#35 <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once () at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/alloc/src/boxed.rs:1575
#36 std::sys::unix::thread::Thread::new::thread_start () at library/std/src/sys/unix/thread.rs:71
#37 0x0000ffffac2f13f0 in start_thread (arg=0xfffe1cbaea9f) at pthread_create.c:477
#38 0x0000ffffac2490dc in thread_start () at ../sysdeps/unix/sysv/linux/aarch64/clone.S:78
```

</details>