### PR TITLE
WORK-396 Import plain transport in mediasoup-elixir

### DIFF
--- a/lib/nif.ex
+++ b/lib/nif.ex
@@ -26,6 +26,9 @@ defmodule Mediasoup.Nif do
   defp router_create_webrtc_transport_async(_router, _option),
     do: :erlang.nif_error(:nif_not_loaded)
 
+  defp router_create_plain_transport_async(_router, _option),
+    do: :erlang.nif_error(:nif_not_loaded)
+
   defp router_dump_async(_router), do: :erlang.nif_error(:nif_not_loaded)
 
   ## pipe_transport with async
@@ -49,6 +52,47 @@ defmodule Mediasoup.Nif do
   defp webrtc_transport_consume_async(_transport, _option), do: :erlang.nif_error(:nif_not_loaded)
   defp webrtc_transport_connect_async(_transport, _option), do: :erlang.nif_error(:nif_not_loaded)
   defp webrtc_transport_produce_async(_transport, _option), do: :erlang.nif_error(:nif_not_loaded)
+
+  # plain transport
+  ## properties
+  def plain_transport_tuple(_transport), do: :erlang.nif_error(:nif_not_loaded)
+  def plain_transport_sctp_parameters(_transport), do: :erlang.nif_error(:nif_not_loaded)
+  def plain_transport_srtp_parameters(_transport), do: :erlang.nif_error(:nif_not_loaded)
+  def plain_transport_sctp_state(_transport), do: :erlang.nif_error(:nif_not_loaded)
+
+  ## methods
+  ### plain transport with async
+  defp plain_transport_connect_async(_transport, _option), do: :erlang.nif_error(:nif_not_loaded)
+  defp plain_transport_dump_async(_transport), do: :erlang.nif_error(:nif_not_loaded)
+  defp plain_transport_get_stats_async(_transport), do: :erlang.nif_error(:nif_not_loaded)
+  defp plain_transport_consume_async(_transport, _option), do: :erlang.nif_error(:nif_not_loaded)
+
+  ### plain tranasport call
+  @spec plain_transport_connect(reference, any) :: {:ok} | {:error, String.t()}
+  def plain_transport_connect(transport, option),
+    do: plain_transport_connect_async(transport, option) |> handle_async_nif_result()
+
+  @spec plain_transport_id(reference) :: String.t()
+  def plain_transport_id(_transport), do: :erlang.nif_error(:nif_not_loaded)
+  @spec plain_transport_dump(reference) :: {:ok} | {:error, String.t()}
+  def plain_transport_dump(transport),
+    do: plain_transport_dump_async(transport) |> handle_async_nif_result() |> unwrap_ok()
+
+  @spec plain_transport_get_stats(reference) :: {:ok} | {:error, String.t()}
+  def plain_transport_get_stats(transport),
+    do: plain_transport_get_stats_async(transport) |> handle_async_nif_result() |> unwrap_ok()
+
+  @spec plain_transport_consume(reference, any) :: {:ok, reference()} | {:error, String.t()}
+  def plain_transport_consume(transport, option),
+    do: plain_transport_consume_async(transport, option) |> handle_async_nif_result()
+
+  @spec plain_transport_close(reference) :: {:ok} | {:error}
+  def plain_transport_close(_transport), do: :erlang.nif_error(:nif_not_loaded)
+
+  ## plain transport event
+  @spec plain_transport_event(reference, pid, [atom()]) :: {:ok} | {:error}
+  def plain_transport_event(_transport, _pid, _event_types),
+    do: :erlang.nif_error(:nif_not_loaded)
 
   ## consumer with async
   defp consumer_get_stats_async(_consumer), do: :erlang.nif_error(:nif_not_loaded)
@@ -115,6 +159,11 @@ defmodule Mediasoup.Nif do
           {:ok, reference()} | {:error, String.t()}
   def router_create_webrtc_transport(router, option),
     do: router_create_webrtc_transport_async(router, option) |> handle_async_nif_result()
+
+  @spec router_create_plain_transport(reference, map) ::
+          {:ok, reference()} | {:error, String.t()}
+  def router_create_plain_transport(router, option),
+    do: router_create_plain_transport_async(router, option) |> handle_async_nif_result()
 
   @spec router_can_consume(reference, String.t(), Router.rtpCapabilities()) :: boolean
   def router_can_consume(_router, _producer_id, _rtp_capabilities),

--- a/lib/plain_transport.ex
+++ b/lib/plain_transport.ex
@@ -1,0 +1,243 @@
+defmodule Mediasoup.PlainTransport do
+  @moduledoc """
+  https://mediasoup.org/documentation/v3/mediasoup/api/#PlainTransport
+  """
+
+  alias Mediasoup.{PlainTransport, Consumer, NifWrap, Nif}
+  require NifWrap
+  use GenServer, restart: :temporary
+
+  @enforce_keys [:id]
+  defstruct [:id, :pid]
+  @type t :: %PlainTransport{id: String.t(), pid: pid}
+
+  defmodule Options do
+    @moduledoc """
+    https://mediasoup.org/documentation/v3/mediasoup/api/#PlainTransportOptions
+    """
+
+    @enforce_keys [:listen_ip]
+    defstruct [
+      :listen_ip,
+      port: nil,
+      rtcp_mux: nil,
+      comedia: nil,
+      enable_sctp: nil,
+      num_sctp_streams: nil,
+      max_sctp_message_size: nil,
+      sctp_send_buffer_size: nil,
+      enable_srtp: nil
+    ]
+
+    @type t :: %Options{
+            listen_ip: Mediasoup.transport_listen_ip(),
+            port: integer() | nil,
+            rtcp_mux: boolean | nil,
+            comedia: boolean | nil,
+            enable_sctp: boolean | nil,
+            num_sctp_streams: Mediasoup.num_sctp_streams() | nil,
+            max_sctp_message_size: integer() | nil,
+            sctp_send_buffer_size: integer() | nil,
+            enable_srtp: boolean | nil
+          }
+
+    def from_map(%{} = map) do
+      map = for {key, val} <- map, into: %{}, do: {to_string(key), val}
+
+      %Options{
+        listen_ip: map["listenIp"],
+        port: map["port"],
+        rtcp_mux: map["rtcpMux"],
+        comedia: map["comedia"],
+        enable_sctp: map["enableSctp"],
+        num_sctp_streams: map["numSctpStreams"],
+        max_sctp_message_size: map["maxSctpMessageSize"],
+        sctp_send_buffer_size: map["sctpSendBufferSize"],
+        enable_srtp: map["enableSrtp"]
+      }
+    end
+  end
+
+  @type transport_stat :: map()
+  @type connect_option :: map()
+  @type create_option :: map | Options.t()
+
+  # Mediasoup Plain Transport Properties
+  # https://mediasoup.org/documentation/v3/mediasoup/api/#PlainTransport-properties
+
+  @spec id(t) :: String.t()
+  @doc """
+  PlainTransport identifier.
+  """
+  def id(%PlainTransport{id: id}) do
+    id
+  end
+
+  @spec tuple(t) :: map() | {:error, :terminated}
+  @doc """
+  The transport tuple. If RTCP-mux is enabled (rtcpMux is set), this tuple refers to both RTP and RTCP.
+  https://mediasoup.org/documentation/v3/mediasoup/api/#plainTransport-tuple
+  """
+  def tuple(%PlainTransport{pid: pid}) do
+    GenServer.call(pid, {:tuple, []})
+  end
+
+  @spec sctp_parameters(t) :: map() | {:error, :terminated}
+  @doc """
+  Local SCTP parameters. Or undefined if SCTP is not enabled.
+  https://mediasoup.org/documentation/v3/mediasoup/api/#plainTransport-sctpParameters
+  """
+  def sctp_parameters(%PlainTransport{pid: pid}) do
+    GenServer.call(pid, {:sctp_parameters, []})
+  end
+
+  @spec sctp_state(t) :: String.t() | {:error, :terminated}
+  @doc """
+  Current SCTP state. Or undefined if SCTP is not enabled.
+  https://mediasoup.org/documentation/v3/mediasoup/api/#plainTransport-sctpState
+  """
+  def sctp_state(%PlainTransport{pid: pid}) do
+    GenServer.call(pid, {:sctp_state, []})
+  end
+
+  @spec srtp_parameters(t) :: map() | {:error, :terminated}
+  @doc """
+  Local SRTP parameters representing the crypto suite and key material used to encrypt sending RTP and SRTP. Note that, if comedia mode is set, these local SRTP parameters may change after calling connect() with the remote SRTP parameters (to override the local SRTP crypto suite with the one given in connect().
+  https://mediasoup.org/documentation/v3/mediasoup/api/#plainTransport-srtpParameters
+  """
+  def srtp_parameters(%PlainTransport{pid: pid}) do
+    GenServer.call(pid, {:srtp_parameters, []})
+  end
+
+  # Mediasoup Plain Transport Methods
+  # https://mediasoup.org/documentation/v3/mediasoup/api/#PlainTransport-methods
+
+  @spec get_stats(t) :: list(transport_stat) | {:error, :terminated}
+  @doc """
+  Returns current RTC statistics of the WebRTC transport.
+  https://mediasoup.org/documentation/v3/mediasoup/api/#plainTransport-getStats
+  """
+  def get_stats(%PlainTransport{pid: pid}) do
+    GenServer.call(pid, {:get_stats, []})
+  end
+
+  @spec connect(t, connect_option()) :: {:ok} | {:error, String.t() | :terminated}
+  @doc """
+  Provides the plain transport with the endpoint parameters.
+  https://mediasoup.org/documentation/v3/mediasoup/api/#plainTransport-connect
+  """
+  def connect(%PlainTransport{pid: pid}, option) do
+    GenServer.call(pid, {:connect, [option]})
+  end
+
+  @spec close(t) :: :ok
+
+  @doc """
+    Closes the PlainTransport.
+  """
+  def close(%PlainTransport{pid: pid}) do
+    GenServer.stop(pid)
+  end
+
+  @spec closed?(t) :: boolean
+  @doc """
+  Tells whether the given PlainTransport is closed on the local node.
+  """
+  def closed?(%PlainTransport{pid: pid}) do
+    !Process.alive?(pid) || GenServer.call(pid, {:closed?, []})
+  end
+
+  NifWrap.def_handle_call_nif(%{
+    # properties
+    id: &Nif.plain_transport_id/1,
+    tuple: &Nif.plain_transport_tuple/1,
+    sctp_parameters: &Nif.plain_transport_sctp_parameters/1,
+    sctp_state: &Nif.plain_transport_sctp_state/1,
+    srtp_parameters: &Nif.plain_transport_srtp_parameters/1,
+    # methods
+    connect: &Nif.plain_transport_connect/2,
+    dump: &Nif.plain_transport_dump/1,
+    get_stats: &Nif.plain_transport_get_stats/1,
+    consume: &Nif.plain_transport_consume/2,
+    close: &Nif.plain_transport_close/1,
+    # events
+    event: &Nif.plain_transport_event/3
+  })
+
+  # Mediasoup Plain Transport Events
+  # https://mediasoup.org/documentation/v3/mediasoup/api/#PlainTransport-events
+
+  @type event_type ::
+          :on_close
+          | :on_tuple
+          | :on_sctp_state_change
+
+  @spec event(t, pid, event_types :: [event_type]) :: {:ok} | {:error, :terminated}
+  @doc """
+  Starts observing event.
+  """
+  def event(
+        transport,
+        listener,
+        event_types \\ [
+          :on_close,
+          :on_tuple,
+          :on_sctp_state_change
+        ]
+      )
+
+  def event(%PlainTransport{pid: pid}, listener, event_types) do
+    GenServer.call(pid, {:event, [listener, event_types]})
+  end
+
+  # GenServer callbacks
+
+  def start_link(opt) do
+    reference = Keyword.fetch!(opt, :reference)
+    GenServer.start_link(__MODULE__, %{reference: reference}, opt)
+  end
+
+  def init(state) do
+    Process.flag(:trap_exit, true)
+    {:ok, supervisor} = DynamicSupervisor.start_link(strategy: :one_for_one)
+
+    {:ok, Map.put(state, :supervisor, supervisor)}
+  end
+
+  @spec struct_from_pid(pid()) :: PlainTransport.t()
+  def struct_from_pid(pid) do
+    GenServer.call(pid, {:struct_from_pid, []})
+  end
+
+  def handle_call(
+        {:struct_from_pid, _arg},
+        _from,
+        %{reference: reference} = state
+      ) do
+    {:reply,
+     %PlainTransport{
+       pid: self(),
+       id: Nif.plain_transport_id(reference)
+     }, state}
+  end
+
+  @spec consume(t, Consumer.Options.t() | map()) ::
+          {:ok, Consumer.t()} | {:error, String.t() | :terminated}
+  @doc """
+  Instructs the router to send audio or video RTP (or SRTP depending on the transport class). This is the way to extract media from mediasoup.
+  https://mediasoup.org/documentation/v3/mediasoup/api/#transport-consume
+  """
+  def consume(%PlainTransport{pid: pid}, %Consumer.Options{} = option) do
+    GenServer.call(pid, {:consume, [option]})
+  end
+
+  def consume(transport, option) do
+    consume(transport, Consumer.Options.from_map(option))
+  end
+
+  def terminate(reason, %{reference: reference, supervisor: supervisor} = _state) do
+    DynamicSupervisor.stop(supervisor, reason)
+    Nif.plain_transport_close(reference)
+    :ok
+  end
+end

--- a/native/mediasoup_elixir/src/lib.rs
+++ b/native/mediasoup_elixir/src/lib.rs
@@ -4,6 +4,7 @@ mod data_structure;
 mod json_serde;
 mod macros;
 mod pipe_transport;
+mod plain_transport;
 mod producer;
 mod resource;
 mod router;
@@ -24,6 +25,11 @@ use crate::pipe_transport::{
     pipe_transport_produce, pipe_transport_sctp_parameters, pipe_transport_sctp_state,
     pipe_transport_srtp_parameters, pipe_transport_tuple,
 };
+use crate::plain_transport::{
+    plain_transport_close, plain_transport_connect, plain_transport_consume, plain_transport_event,
+    plain_transport_get_stats, plain_transport_id, plain_transport_sctp_parameters,
+    plain_transport_sctp_state, plain_transport_srtp_parameters, plain_transport_tuple,
+};
 use crate::producer::{
     producer_close, producer_closed, producer_dump, producer_event, producer_get_stats,
     producer_id, producer_kind, producer_pause, producer_paused, producer_resume,
@@ -32,7 +38,8 @@ use crate::producer::{
 use crate::resource::DisposableResourceWrapper;
 use crate::router::{
     router_can_consume, router_close, router_closed, router_create_pipe_transport,
-    router_create_webrtc_transport, router_dump, router_event, router_id, router_rtp_capabilities,
+    router_create_plain_transport, router_create_webrtc_transport, router_dump, router_event,
+    router_id, router_rtp_capabilities,
 };
 use crate::webrtc_transport::{
     webrtc_transport_close, webrtc_transport_closed, webrtc_transport_connect,
@@ -52,6 +59,7 @@ use crate::worker::{
 use futures_lite::future;
 use mediasoup::consumer::Consumer;
 use mediasoup::pipe_transport::PipeTransport;
+use mediasoup::plain_transport::PlainTransport;
 use mediasoup::producer::Producer;
 use mediasoup::router::Router;
 use mediasoup::webrtc_transport::WebRtcTransport;
@@ -116,6 +124,7 @@ rustler::init! {
         router_close,
         router_closed,
         router_create_webrtc_transport,
+        router_create_plain_transport,
         router_can_consume,
         router_rtp_capabilities,
         router_create_pipe_transport,
@@ -161,6 +170,17 @@ rustler::init! {
         pipe_transport_dump,
         pipe_transport_event,
 
+        // plain transport
+        plain_transport_id,
+        plain_transport_tuple,
+        plain_transport_sctp_parameters,
+        plain_transport_sctp_state,
+        plain_transport_srtp_parameters,
+        plain_transport_connect,
+        plain_transport_get_stats,
+        plain_transport_consume,
+        plain_transport_close,
+        plain_transport_event,
 
         // consumer
         consumer_id,
@@ -214,6 +234,7 @@ fn on_load<'a>(env: Env<'a>, _load_info: Term<'a>) -> bool {
     rustler::resource!(RouterRef, env);
     rustler::resource!(WebRtcTransportRef, env);
     rustler::resource!(PipeTransportRef, env);
+    rustler::resource!(PlainTransportRef, env);
     rustler::resource!(ConsumerRef, env);
     rustler::resource!(ProducerRef, env);
     true
@@ -223,5 +244,6 @@ pub type WorkerRef = DisposableResourceWrapper<Worker>;
 pub type RouterRef = DisposableResourceWrapper<Router>;
 pub type WebRtcTransportRef = DisposableResourceWrapper<WebRtcTransport>;
 pub type PipeTransportRef = DisposableResourceWrapper<PipeTransport>;
+pub type PlainTransportRef = DisposableResourceWrapper<PlainTransport>;
 pub type ConsumerRef = DisposableResourceWrapper<Consumer>;
 pub type ProducerRef = DisposableResourceWrapper<Producer>;

--- a/native/mediasoup_elixir/src/plain_transport.rs
+++ b/native/mediasoup_elixir/src/plain_transport.rs
@@ -1,0 +1,185 @@
+use crate::consumer::ConsumerOptionsStruct;
+use crate::data_structure::SerNumSctpStreams;
+use crate::json_serde::JsonSerdeWrap;
+use crate::PlainTransportRef;
+use crate::{atoms, send_async_nif_result, ConsumerRef};
+use mediasoup::consumer::ConsumerOptions;
+use mediasoup::data_structures::{ListenIp, SctpState, TransportTuple};
+use mediasoup::plain_transport::{PlainTransportOptions, PlainTransportRemoteParameters};
+use mediasoup::prelude::Transport;
+use mediasoup::sctp_parameters::SctpParameters;
+use mediasoup::srtp_parameters::SrtpParameters;
+use mediasoup::transport::{TransportGeneric, TransportId};
+use rustler::{Atom, Env, NifResult, NifStruct, ResourceArc};
+
+#[derive(NifStruct)]
+#[module = "Mediasoup.PlainTransport.Options"]
+pub struct PlainTransportOptionsStruct {
+    pub listen_ip: JsonSerdeWrap<ListenIp>,
+    pub port: Option<u16>,
+    pub rtcp_mux: Option<bool>,
+    pub comedia: Option<bool>,
+    pub enable_sctp: Option<bool>,
+    num_sctp_streams: Option<JsonSerdeWrap<SerNumSctpStreams>>,
+    pub max_sctp_message_size: Option<u32>,
+    pub sctp_send_buffer_size: Option<u32>,
+    pub enable_srtp: Option<bool>,
+}
+impl PlainTransportOptionsStruct {
+    pub fn try_to_option(&self) -> Result<PlainTransportOptions, &'static str> {
+        let mut option = PlainTransportOptions::new(*self.listen_ip);
+
+        option.port = self.port;
+
+        if let Some(rtcp_mux) = self.rtcp_mux {
+            option.rtcp_mux = rtcp_mux;
+        }
+        if let Some(comedia) = self.comedia {
+            option.comedia = comedia;
+        }
+        if let Some(enable_sctp) = self.enable_sctp {
+            option.enable_sctp = enable_sctp;
+        }
+        if let Some(num_sctp_streams) = &self.num_sctp_streams {
+            option.num_sctp_streams = num_sctp_streams.as_streams();
+        }
+        if let Some(max_sctp_message_size) = self.max_sctp_message_size {
+            option.max_sctp_message_size = max_sctp_message_size;
+        }
+        if let Some(sctp_send_buffer_size) = self.sctp_send_buffer_size {
+            option.sctp_send_buffer_size = sctp_send_buffer_size;
+        }
+        if let Some(enable_srtp) = self.enable_srtp {
+            option.enable_srtp = enable_srtp;
+        }
+
+        Ok(option)
+    }
+}
+
+#[rustler::nif]
+pub fn plain_transport_id(
+    transport: ResourceArc<PlainTransportRef>,
+) -> NifResult<JsonSerdeWrap<TransportId>> {
+    let transport = transport.get_resource()?;
+    Ok(transport.id().into())
+}
+
+#[rustler::nif]
+pub fn plain_transport_tuple(
+    transport: ResourceArc<PlainTransportRef>,
+) -> NifResult<JsonSerdeWrap<TransportTuple>> {
+    let transport = transport.get_resource()?;
+    Ok(JsonSerdeWrap::new(transport.tuple()))
+}
+
+#[rustler::nif]
+pub fn plain_transport_sctp_parameters(
+    transport: ResourceArc<PlainTransportRef>,
+) -> NifResult<JsonSerdeWrap<Option<SctpParameters>>> {
+    let transport = transport.get_resource()?;
+    Ok(JsonSerdeWrap::new(transport.sctp_parameters()))
+}
+
+#[rustler::nif]
+pub fn plain_transport_sctp_state(
+    transport: ResourceArc<PlainTransportRef>,
+) -> NifResult<JsonSerdeWrap<Option<SctpState>>> {
+    let transport = transport.get_resource()?;
+    Ok(JsonSerdeWrap::new(transport.sctp_state()))
+}
+
+#[rustler::nif]
+pub fn plain_transport_srtp_parameters(
+    transport: ResourceArc<PlainTransportRef>,
+) -> NifResult<JsonSerdeWrap<Option<SrtpParameters>>> {
+    let transport = transport.get_resource()?;
+    Ok(JsonSerdeWrap::new(transport.srtp_parameters()))
+}
+
+#[rustler::nif(name = "plain_transport_connect_async")]
+pub fn plain_transport_connect(
+    env: Env,
+    transport: ResourceArc<PlainTransportRef>,
+    option: JsonSerdeWrap<PlainTransportRemoteParameters>,
+) -> NifResult<(Atom, Atom)> {
+    let transport = transport.get_resource()?;
+    let option: PlainTransportRemoteParameters = option.clone();
+
+    send_async_nif_result(env, async move {
+        transport
+            .connect(option)
+            .await
+            .map_err(|error| format!("{}", error))
+    })
+}
+
+#[rustler::nif(name = "plain_transport_get_stats_async")]
+pub fn plain_transport_get_stats(
+    env: Env,
+    transport: ResourceArc<PlainTransportRef>,
+) -> NifResult<(Atom, Atom)> {
+    let transport = transport.get_resource()?;
+
+    send_async_nif_result(env, async move {
+        transport
+            .get_stats()
+            .await
+            .map(JsonSerdeWrap::new)
+            .map_err(|error| format!("{}", error))
+    })
+}
+
+#[rustler::nif(name = "plain_transport_consume_async")]
+pub fn plain_transport_consume(
+    env: Env,
+    transport: ResourceArc<PlainTransportRef>,
+    option: ConsumerOptionsStruct,
+) -> NifResult<(Atom, Atom)> {
+    let transport = transport.get_resource()?;
+
+    let option: ConsumerOptions = option.to_option();
+
+    send_async_nif_result(env, async move {
+        transport
+            .consume(option)
+            .await
+            .map(ConsumerRef::resource)
+            .map_err(|error| format!("{}", error))
+    })
+}
+
+#[rustler::nif]
+pub fn plain_transport_close(transport: ResourceArc<PlainTransportRef>) -> NifResult<(Atom,)> {
+    transport.close();
+    Ok((atoms::ok(),))
+}
+
+#[rustler::nif]
+pub fn plain_transport_closed(transport: ResourceArc<PlainTransportRef>) -> NifResult<bool> {
+    match transport.get_resource() {
+        Ok(transport) => Ok(transport.closed()),
+        Err(_) => Ok(true),
+    }
+}
+
+#[rustler::nif]
+pub fn plain_transport_event(
+    transport: ResourceArc<PlainTransportRef>,
+    pid: rustler::LocalPid,
+    event_types: Vec<Atom>,
+) -> NifResult<(Atom,)> {
+    let transport = transport.get_resource()?;
+
+    if event_types.contains(&atoms::on_close()) {
+        crate::reg_callback_once!(pid, transport, on_close);
+    }
+    if event_types.contains(&atoms::on_sctp_state_change()) {
+        crate::reg_callback_json_param!(pid, transport, on_sctp_state_change);
+    }
+    if event_types.contains(&atoms::on_tuple()) {
+        crate::reg_callback_json_clone_param!(pid, transport, on_tuple);
+    }
+
+    Ok((atoms::ok(),))
+}

--- a/native/mediasoup_elixir/src/router.rs
+++ b/native/mediasoup_elixir/src/router.rs
@@ -1,8 +1,11 @@
 use crate::atoms;
 use crate::json_serde::JsonSerdeWrap;
 use crate::pipe_transport::PipeTransportOptionsStruct;
+use crate::plain_transport::PlainTransportOptionsStruct;
 use crate::webrtc_transport::WebRtcTransportOptionsStruct;
-use crate::{send_async_nif_result, PipeTransportRef, RouterRef, WebRtcTransportRef};
+use crate::{
+    send_async_nif_result, PipeTransportRef, PlainTransportRef, RouterRef, WebRtcTransportRef,
+};
 use mediasoup::producer::ProducerId;
 use mediasoup::router::{RouterId, RouterOptions};
 use mediasoup::rtp_parameters::{RtpCapabilities, RtpCapabilitiesFinalized, RtpCodecCapability};
@@ -40,6 +43,26 @@ pub fn router_create_webrtc_transport(
             .create_webrtc_transport(option)
             .await
             .map(WebRtcTransportRef::resource)
+            .map_err(|error| format!("{}", error))
+    })
+}
+
+#[rustler::nif(name = "router_create_plain_transport_async")]
+pub fn router_create_plain_transport(
+    env: Env,
+    router: ResourceArc<RouterRef>,
+    option: PlainTransportOptionsStruct,
+) -> NifResult<(rustler::Atom, rustler::Atom)> {
+    let router = router.get_resource()?;
+    let option = option
+        .try_to_option()
+        .map_err(|error| Error::Term(Box::new(error.to_string())))?;
+
+    send_async_nif_result(env, async move {
+        router
+            .create_plain_transport(option)
+            .await
+            .map(PlainTransportRef::resource)
             .map_err(|error| format!("{}", error))
     })
 }

--- a/test/integration/test_plain_transport.ex
+++ b/test/integration/test_plain_transport.ex
@@ -1,0 +1,455 @@
+defmodule IntegrateTest.PlainTransportTest do
+  @moduledoc """
+  test for PlainTransport with dialyzer check
+  """
+
+  import ExUnit.Assertions
+  alias Mediasoup.{PlainTransport, Router}
+
+  defp init(worker) do
+    alias Mediasoup.{Worker, Router}
+
+    Worker.event(worker, self())
+
+    {:ok, router} =
+      Worker.create_router(worker, %{
+        mediaCodecs: media_codecs()
+      })
+
+    {worker, router}
+  end
+
+  def webrtc_init(worker) do
+    alias Mediasoup.{Worker, Router}
+    Worker.event(worker, self())
+
+    {:ok, router} =
+      Worker.create_router(worker, %{
+        mediaCodecs: media_codecs()
+      })
+
+    {:ok, transport_1} =
+      Router.create_webrtc_transport(router, %{
+        listenIps: {
+          %{
+            ip: "127.0.0.1"
+          }
+        }
+      })
+
+    {worker, router, transport_1}
+  end
+
+  defp media_codecs() do
+    {
+      %{
+        kind: "audio",
+        mimeType: "audio/opus",
+        clockRate: 48_000,
+        channels: 2,
+        parameters: %{"foo" => "bar"},
+        rtcpFeedback: []
+      },
+      %{
+        kind: "video",
+        mimeType: "video/VP8",
+        clockRate: 90000,
+        parameters: %{},
+        rtcpFeedback: []
+      },
+      %{
+        kind: "video",
+        mimeType: "video/H264",
+        clockRate: 90_000,
+        parameters: %{
+          "level-asymmetry-allowed" => 1,
+          "packetization-mode" => 1,
+          "profile-level-id" => "4d0032",
+          "foo" => "bar"
+        },
+        rtcpFeedback: []
+      }
+    }
+  end
+
+  def consumer_device_capabilities() do
+    %{
+      codecs:
+        {%{
+           kind: "audio",
+           mimeType: "audio/opus",
+           preferredPayloadType: 100,
+           clockRate: 48000,
+           channels: 2,
+           parameters: %{},
+           rtcpFeedback: []
+         },
+         %{
+           kind: "video",
+           mimeType: "video/VP8",
+           preferredPayloadType: 101,
+           clockRate: 90000,
+           parameters: %{},
+           rtcpFeedback: [
+             %{type: "nack"},
+             %{type: "ccm", parameter: "fir"},
+             %{type: "transport-cc"}
+           ]
+         },
+         %{
+           kind: "video",
+           mimeType: "video/rtx",
+           payloadType: 102,
+           clockRate: 90000,
+           parameters: %{
+             "apt" => 101
+           },
+           rtcpFeedback: []
+         }},
+      headerExtensions: {
+        %{
+          kind: "video",
+          uri: "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time",
+          preferredId: 4,
+          preferredEncrypt: false,
+          direction: "sendrecv"
+        },
+        %{
+          kind: "video",
+          uri: "http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01",
+          preferredId: 5,
+          preferredEncrypt: false,
+          direction: "sendrecv"
+        },
+        %{
+          kind: "audio",
+          uri: "urn:ietf:params:rtp-hdrext:ssrc-audio-level",
+          preferredId: 10,
+          preferredEncrypt: false,
+          direction: "sendrecv"
+        }
+      },
+      fecMechanisms: {}
+    }
+  end
+
+  def video_producer_options() do
+    %{
+      kind: "video",
+      rtpParameters: %{
+        mid: "VIDEO",
+        codecs:
+          {%{
+             mimeType: "video/VP8",
+             payloadType: 112,
+             clockRate: 90000,
+             parameters: %{
+               "packetization-mode" => 1,
+               "profile-level-id" => "4d0032"
+             },
+             rtcpFeedback: [
+               %{type: "nack"},
+               %{type: "nack", parameter: "pli"},
+               %{type: "goog-remb"}
+             ]
+           },
+           %{
+             mimeType: "video/rtx",
+             payloadType: 113,
+             clockRate: 90000,
+             parameters: %{
+               "apt" => 112
+             },
+             rtcpFeedback: []
+           }},
+        headerExtensions: [
+          %{
+            uri: "urn:ietf:params:rtp-hdrext:sdes:mid",
+            id: 10,
+            encrypt: false
+          },
+          %{
+            uri: "urn:ietf:params:rtp-hdrext:sdes:mid",
+            id: 10,
+            encrypt: false
+          },
+          %{
+            uri: "urn:3gpp:video-orientation",
+            id: 13,
+            encrypt: false
+          }
+        ],
+        encodings: [
+          %{
+            ssrc: 22_222_222,
+            rtx: %{ssrc: 22_222_223}
+          },
+          %{
+            ssrc: 22_222_224,
+            rtx: %{ssrc: 22_222_225}
+          },
+          %{
+            ssrc: 22_222_226,
+            rtx: %{ssrc: 22_222_227}
+          },
+          %{
+            ssrc: 22_222_228,
+            rtx: %{ssrc: 22_222_229}
+          }
+        ],
+        rtcp: %{
+          cname: "FOOBAR",
+          reducedSize: true
+        }
+      }
+    }
+  end
+
+  def create_succeeds(worker) do
+    test_create_succeeds_with_ip_only(worker)
+    test_create_succeeds_with_sctp_enabled(worker)
+    test_create_succeeds_with_srtp_enabled(worker)
+  end
+
+  defp test_create_succeeds_with_ip_only(worker) do
+    {_worker, router} = init(worker)
+
+    {:ok, transport} =
+      Router.create_plain_transport(router, %{listenIp: %{ip: "127.0.0.1"}, comedia: false})
+
+    assert transport.id == PlainTransport.id(transport)
+
+    assert match?(
+             %{"localIp" => "127.0.0.1", "localPort" => _, "protocol" => "udp"},
+             PlainTransport.tuple(transport)
+           )
+  end
+
+  defp test_create_succeeds_with_sctp_enabled(worker) do
+    {_worker, router} = init(worker)
+
+    {:ok, transport} =
+      Router.create_plain_transport(router, %{listenIp: %{ip: "127.0.0.1"}, enableSctp: true})
+
+    assert transport.id == PlainTransport.id(transport)
+
+    assert match?(
+             %{"localIp" => "127.0.0.1", "localPort" => _, "protocol" => "udp"},
+             PlainTransport.tuple(transport)
+           )
+
+    assert %{"MIS" => 1024, "OS" => 1024, "maxMessageSize" => 262_144, "port" => 5000} ==
+             PlainTransport.sctp_parameters(transport)
+
+    assert PlainTransport.sctp_state(transport) == "new"
+  end
+
+  defp test_create_succeeds_with_srtp_enabled(worker) do
+    {_worker, router} = init(worker)
+
+    {:ok, transport} =
+      Router.create_plain_transport(router, %{listenIp: %{ip: "127.0.0.1"}, enableSrtp: true})
+
+    assert transport.id == PlainTransport.id(transport)
+
+    assert match?(
+             %{"localIp" => "127.0.0.1", "localPort" => _, "protocol" => "udp"},
+             PlainTransport.tuple(transport)
+           )
+
+    assert match?(
+             %{
+               "cryptoSuite" => "AES_CM_128_HMAC_SHA1_80",
+               "keyBase64" => _
+             },
+             PlainTransport.srtp_parameters(transport)
+           )
+  end
+
+  def close(worker) do
+    {_worker, router} = init(worker)
+
+    {:ok, transport} =
+      Router.create_plain_transport(router, %{
+        listenIp: %{
+          ip: "127.0.0.1"
+        }
+      })
+
+    assert PlainTransport.id(transport) == transport.id
+    PlainTransport.close(transport)
+    assert PlainTransport.closed?(transport)
+  end
+
+  def create_non_bindable_ip(worker) do
+    {_worker, router} = init(worker)
+
+    Mediasoup.Worker.update_settings(worker, %Mediasoup.Worker.UpdateableSettings{
+      log_level: :none,
+      log_tags: []
+    })
+
+    {:error, _message} =
+      Router.create_plain_transport(router, %{
+        listenIp: %{
+          ip: "8.8.8.8"
+        }
+      })
+  end
+
+  def get_stats_succeeds(worker) do
+    {_worker, router} = init(worker)
+
+    {:ok, transport} =
+      Router.create_plain_transport(router, %{
+        listenIp: %{
+          ip: "127.0.0.1"
+        }
+      })
+
+    stats = PlainTransport.get_stats(transport)
+
+    transport_id = transport.id
+
+    assert match?(
+             [
+               %{
+                 "bytesReceived" => 0,
+                 "bytesSent" => 0,
+                 "comedia" => false,
+                 "probationBytesSent" => 0,
+                 "probationSendBitrate" => 0,
+                 "recvBitrate" => 0,
+                 "rtcpMux" => true,
+                 "rtcpTuple" => nil,
+                 "rtpBytesReceived" => 0,
+                 "rtpBytesSent" => 0,
+                 "rtpRecvBitrate" => 0,
+                 "rtpSendBitrate" => 0,
+                 "rtxBytesReceived" => 0,
+                 "rtxBytesSent" => 0,
+                 "rtxRecvBitrate" => 0,
+                 "rtxSendBitrate" => 0,
+                 "sctpState" => nil,
+                 "sendBitrate" => 0,
+                 "timestamp" => _,
+                 "transportId" => ^transport_id,
+                 "tuple" => %{
+                   "localIp" => "127.0.0.1",
+                   "localPort" => _,
+                   "protocol" => "udp"
+                 }
+               }
+             ],
+             stats
+           )
+  end
+
+  def connect_succeeds(worker) do
+    {_worker, router} = init(worker)
+
+    {:ok, transport} =
+      Router.create_plain_transport(router, %{
+        listenIp: %{
+          ip: "127.0.0.1"
+        }
+      })
+
+    assert {:ok} == PlainTransport.connect(transport, %{ip: "127.0.0.1", port: 4000})
+  end
+
+  def close_event(worker) do
+    {_worker, router} = init(worker)
+
+    {:ok, transport} =
+      Router.create_plain_transport(router, %{
+        listenIp: %{
+          ip: "127.0.0.1"
+        }
+      })
+
+    PlainTransport.event(transport, self())
+    PlainTransport.close(transport)
+
+    assert_receive {:on_close}
+  end
+
+  def close_router_event(worker) do
+    {_worker, router} = init(worker)
+
+    {:ok, transport} =
+      Router.create_plain_transport(router, %{
+        listenIp: %{
+          ip: "127.0.0.1"
+        }
+      })
+
+    PlainTransport.event(transport, self())
+    Mediasoup.Router.close(router)
+    assert PlainTransport.closed?(transport)
+    assert_receive {:on_close}
+  end
+
+  def create_many_plain_transport() do
+    {:ok, worker} =
+      Mediasoup.Worker.start_link(
+        settings: %{
+          rtcMinPort: 30000,
+          rtcMaxPort: 30005,
+          logLevel: :none
+        }
+      )
+
+    {_worker, router} = init(worker)
+
+    transports =
+      1..6
+      |> Enum.map(fn _ ->
+        {:ok, transport} =
+          Router.create_plain_transport(router, %{
+            listenIp: %{
+              ip: "127.0.0.1"
+            }
+          })
+
+        transport
+      end)
+
+    # no more available ports
+    {:error, _} =
+      Router.create_plain_transport(router, %{
+        listenIp: %{
+          ip: "127.0.0.1"
+        }
+      })
+
+    transports
+    |> Enum.map(fn transport ->
+      PlainTransport.close(transport)
+    end)
+  end
+
+  def consume_success(worker) do
+    {_worker, router, webrtc_transport} = webrtc_init(worker)
+
+    {:ok, plain_transport} =
+      Router.create_plain_transport(router, %{
+        listenIp: %{
+          ip: "127.0.0.1"
+        }
+      })
+
+    assert {:ok} == PlainTransport.connect(plain_transport, %{ip: "127.0.0.1", port: 4000})
+
+    {:ok, video_producer} =
+      Mediasoup.WebRtcTransport.produce(webrtc_transport, video_producer_options())
+
+    assert match?(
+             {:ok, _},
+             PlainTransport.consume(plain_transport, %{
+               producerId: video_producer.id,
+               rtpCapabilities: consumer_device_capabilities()
+             })
+           )
+  end
+end

--- a/test/plain_transport_test.exs
+++ b/test/plain_transport_test.exs
@@ -1,0 +1,48 @@
+defmodule MediasoupElixirPlainTransportTest do
+  use ExUnit.Case
+
+  import Mediasoup.TestUtil
+  setup_all :worker_leak_setup_all
+  setup :verify_worker_leak_on_exit!
+
+  setup do
+    {:ok, worker} = Mediasoup.Worker.start_link()
+    %{worker: worker}
+  end
+
+  test "create_succeeds", %{worker: worker} do
+    IntegrateTest.PlainTransportTest.create_succeeds(worker)
+  end
+
+  test "close", %{worker: worker} do
+    IntegrateTest.PlainTransportTest.close(worker)
+  end
+
+  test "create_non_bindable_ip", %{worker: worker} do
+    IntegrateTest.PlainTransportTest.create_non_bindable_ip(worker)
+  end
+
+  test "get_stats_succeeds", %{worker: worker} do
+    IntegrateTest.PlainTransportTest.get_stats_succeeds(worker)
+  end
+
+  test "connect_succeeds", %{worker: worker} do
+    IntegrateTest.PlainTransportTest.connect_succeeds(worker)
+  end
+
+  test "close_event", %{worker: worker} do
+    IntegrateTest.PlainTransportTest.close_event(worker)
+  end
+
+  test "close_router_event", %{worker: worker} do
+    IntegrateTest.PlainTransportTest.close_router_event(worker)
+  end
+
+  test "create_many_plain_transport" do
+    IntegrateTest.PlainTransportTest.create_many_plain_transport()
+  end
+
+  test "consume_success", %{worker: worker} do
+    IntegrateTest.PlainTransportTest.consume_success(worker)
+  end
+end


### PR DESCRIPTION
### Jira task
https://ovice.atlassian.net/browse/WORK-396

###  Description
Importing [Plain transport APIs](https://mediasoup.org/documentation/v3/mediasoup/api/#PlainTransport) to mediasoup, for the purpose of using it in ex-core in order to forward the media streams to recording server.

###  Implementation
1. Added [rust plain transport methods, properties and event ](https://docs.rs/mediasoup/0.8.4/mediasoup/prelude/struct.PlainTransport.html)in plain_transport.rs.
2. Added the appropriate nifs for each property, method and event.
3. Added a new Plain Transport elixir module which uses the properties/methods/event nifs of the existing library written in rust.
4. Plain transport module can be called in ex-core similarly like WebrtcTransport and PipeTransport modules.
5. In order to use plain transport in ex-core, once a specific user starts producing the media, we need to forward the streams as well to the recording server:

###  Steps to use Plain Transport in ex-core
we need to pass through 3 steps to be able to link to the external endpoint
1. create plain transport with external endpoint IP
2. after the above step, we can call `PlainTransport.tuple(transport)` to get the open port of the external endpoint.
3. we connect to the IP and port
4. we start consuming (ex-core -> recording server), with recording server being the consumer.

```elixir
options = %{
      listenIp: %{ip: listen_ip},
}

{:ok, plain_transport} = Mediasoup.Router.create_plain_transport(router, options)
## we can use `PlainTransport.tuple(transport)` to know the appropriate open port to connect to
{:ok} = Mediasoup.PlainTransport.connect(plain_transport, %{ip: listen_ip, port: port})

Mediasoup.PlainTransport.consume(plain_transport, %{
      producerId: producer_id,
      rtpCapabilities: consumer_rtp_capabilities
})
```

###  TO DO in next PR (in ex-core)
Will use the above code to link the user's media to the recording server (membrane).
Task: https://ovice.atlassian.net/browse/WORK-397

