### PR TITLE
call consume by elixir and not by nifwrap

### DIFF
--- a/lib/plain_transport.ex
+++ b/lib/plain_transport.ex
@@ -158,7 +158,6 @@ defmodule Mediasoup.PlainTransport do
     connect: &Nif.plain_transport_connect/2,
     dump: &Nif.plain_transport_dump/1,
     get_stats: &Nif.plain_transport_get_stats/1,
-    consume: &Nif.plain_transport_consume/2,
     close: &Nif.plain_transport_close/1,
     # events
     event: &Nif.plain_transport_event/3
@@ -219,6 +218,18 @@ defmodule Mediasoup.PlainTransport do
        pid: self(),
        id: Nif.plain_transport_id(reference)
      }, state}
+  end
+
+  def handle_call(
+        {:consume, [option]},
+        _from,
+        %{reference: reference, supervisor: supervisor} = state
+      ) do
+    ret =
+      Nif.plain_transport_consume(reference, option)
+      |> NifWrap.handle_create_result(Consumer, supervisor)
+
+    {:reply, ret, state}
   end
 
   @spec consume(t, Consumer.Options.t() | map()) ::


### PR DESCRIPTION
## Changes

using `&Nif.plain_transport_consume/2`, the return value is `{:ok, #reference}`

I changed the call of the consume method to be handled by elixir server instead, to be able to get the consumer object,
so now the return value is 
`{:ok, Mediasoup.Consumer}`

This change is needed to get the consumer's `rtp_parameters` later when exchanging them with the recording server, to create the correct sdp offer with ffmpeg.