### PR TITLE
Revert "Update mediasoup to 0.10.0 (#153)"

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule MediasoupElixir.MixProject do
   def project do
     [
       app: :mediasoup_elixir,
-      version: "0.4.1",
+      version: "0.4.2",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/native/mediasoup_elixir/Cargo.toml
+++ b/native/mediasoup_elixir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mediasoup_elixir"
-version = "0.4.1"
+version = "0.4.2"
 authors = []
 edition = "2021"
 
@@ -11,8 +11,11 @@ crate-type = ["cdylib"]
 
 [dependencies]
 rustler = "0.23.0"
-mediasoup = "0.10.0"
-mediasoup-sys = ">=0.4.2" # 0.4.1 has crash issue, so avoid it. https://github.com/versatica/mediasoup/issues/861
+# 0.4.1 has crash issue, so avoid it. https://github.com/versatica/mediasoup/issues/861
+# 0.4.2 is crash problem remains.
+# Prior to that, compile error
+mediasoup-sys = { git = "https://github.com/satoren/mediasoup", tag = "rust-0.9.4", version = "0.3.3" }
+mediasoup = { git = "https://github.com/satoren/mediasoup", tag = "rust-0.9.4", version = "0.9.4" }
 futures-lite = "1.12.0"
 once_cell = "1.12.0"
 num_cpus = "1.13.1"
@@ -22,4 +25,3 @@ serde-transcode = "1.1"
 serde_json = "1.0"
 serde_rustler = { path = "local_deps/serde_rustler/serde_rustler" }
 env_logger = "0.9.0"
-

--- a/native/mediasoup_elixir/src/pipe_transport.rs
+++ b/native/mediasoup_elixir/src/pipe_transport.rs
@@ -4,7 +4,7 @@ use crate::data_structure::SerNumSctpStreams;
 use crate::json_serde::JsonSerdeWrap;
 use crate::producer::ProducerOptionsStruct;
 use crate::{send_async_nif_result, ConsumerRef, PipeTransportRef, ProducerRef};
-use mediasoup::data_structures::{ListenIp, SctpState, TransportTuple};
+use mediasoup::data_structures::{SctpState, TransportListenIp, TransportTuple};
 use mediasoup::pipe_transport::{PipeTransportOptions, PipeTransportRemoteParameters};
 use mediasoup::sctp_parameters::SctpParameters;
 use mediasoup::srtp_parameters::SrtpParameters;
@@ -16,7 +16,7 @@ use rustler::{Atom, Env, NifResult, NifStruct, ResourceArc};
 #[module = "Mediasoup.PipeTransport.Options"]
 pub struct PipeTransportOptionsStruct {
     /// Listening IP address.
-    pub listen_ip: JsonSerdeWrap<ListenIp>,
+    pub listen_ip: JsonSerdeWrap<TransportListenIp>,
     /// Fixed port to listen on instead of selecting automatically from Worker's port range.
     pub port: Option<u16>,
     /// Create a SCTP association.

--- a/native/mediasoup_elixir/src/plain_transport.rs
+++ b/native/mediasoup_elixir/src/plain_transport.rs
@@ -4,7 +4,7 @@ use crate::json_serde::JsonSerdeWrap;
 use crate::PlainTransportRef;
 use crate::{atoms, send_async_nif_result, ConsumerRef};
 use mediasoup::consumer::ConsumerOptions;
-use mediasoup::data_structures::{ListenIp, SctpState, TransportTuple};
+use mediasoup::data_structures::{SctpState, TransportListenIp, TransportTuple};
 use mediasoup::plain_transport::{PlainTransportOptions, PlainTransportRemoteParameters};
 use mediasoup::prelude::Transport;
 use mediasoup::sctp_parameters::SctpParameters;
@@ -15,7 +15,7 @@ use rustler::{Atom, Env, NifResult, NifStruct, ResourceArc};
 #[derive(NifStruct)]
 #[module = "Mediasoup.PlainTransport.Options"]
 pub struct PlainTransportOptionsStruct {
-    pub listen_ip: JsonSerdeWrap<ListenIp>,
+    pub listen_ip: JsonSerdeWrap<TransportListenIp>,
     pub port: Option<u16>,
     pub rtcp_mux: Option<bool>,
     pub comedia: Option<bool>,

--- a/native/mediasoup_elixir/src/webrtc_transport.rs
+++ b/native/mediasoup_elixir/src/webrtc_transport.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use mediasoup::consumer::ConsumerOptions;
 use mediasoup::data_structures::{
-    DtlsParameters, DtlsState, IceParameters, IceRole, IceState, ListenIp, SctpState,
+    DtlsParameters, DtlsState, IceParameters, IceRole, IceState, SctpState, TransportListenIp,
     TransportTuple,
 };
 use mediasoup::producer::ProducerOptions;
@@ -287,7 +287,7 @@ pub fn webrtc_transport_event(
 #[derive(NifStruct)]
 #[module = "Mediasoup.WebRtcTransport.Options"]
 pub struct WebRtcTransportOptionsStruct {
-    listen_ips: JsonSerdeWrap<Vec<ListenIp>>,
+    listen_ips: JsonSerdeWrap<Vec<TransportListenIp>>,
     enable_udp: Option<bool>,
     enable_tcp: Option<bool>,
     prefer_udp: Option<bool>,

--- a/test/integration/test_pipe_transport.ex
+++ b/test/integration/test_pipe_transport.ex
@@ -529,8 +529,7 @@ defmodule IntegrateTest.PipeTransportTest do
 
     srtp_parameters = PipeTransport.srtp_parameters(pipe_transport)
     assert match?(%{}, srtp_parameters)
-    assert srtp_parameters["cryptoSuite"] == "AEAD_AES_256_GCM"
-    assert String.length(srtp_parameters["keyBase64"]) == 60
+    assert String.length(srtp_parameters["keyBase64"]) == 40
 
     Mediasoup.Worker.update_settings(worker, %Mediasoup.Worker.UpdateableSettings{
       log_level: :none,
@@ -547,8 +546,8 @@ defmodule IntegrateTest.PipeTransportTest do
         ip: "127.0.0.2",
         port: 9999,
         srtpParameters: %{
-          cryptoSuite: "AEAD_AES_256_GCM",
-          keyBase64: "YTdjcDBvY2JoMGY5YXNlNDc0eDJsdGgwaWRvNnJsamRrdG16aWVpZHphdHo="
+          cryptoSuite: "AES_CM_128_HMAC_SHA1_80",
+          keyBase64: "ZnQ3eWJraDg0d3ZoYzM5cXN1Y2pnaHU5NWxrZTVv"
         }
       })
   end


### PR DESCRIPTION
Because 0.10.0 is unstable

And created a patched version for 0.9.3 because it can not build by [this](https://github.com/versatica/mediasoup/pull/859) error.

Crash report.
https://github.com/versatica/mediasoup/issues/882
https://github.com/versatica/mediasoup/issues/883