### PR TITLE
WORK-582 add missing 'closed?' nif correspondance in plain transport

### DIFF
--- a/lib/nif.ex
+++ b/lib/nif.ex
@@ -89,6 +89,9 @@ defmodule Mediasoup.Nif do
   @spec plain_transport_close(reference) :: {:ok} | {:error}
   def plain_transport_close(_transport), do: :erlang.nif_error(:nif_not_loaded)
 
+  @spec plain_transport_closed(reference) :: boolean
+  def plain_transport_closed(_transport), do: :erlang.nif_error(:nif_not_loaded)
+
   ## plain transport event
   @spec plain_transport_event(reference, pid, [atom()]) :: {:ok} | {:error}
   def plain_transport_event(_transport, _pid, _event_types),

--- a/lib/plain_transport.ex
+++ b/lib/plain_transport.ex
@@ -159,6 +159,7 @@ defmodule Mediasoup.PlainTransport do
     dump: &Nif.plain_transport_dump/1,
     get_stats: &Nif.plain_transport_get_stats/1,
     close: &Nif.plain_transport_close/1,
+    closed?: &Nif.plain_transport_closed/1,
     # events
     event: &Nif.plain_transport_event/3
   })

--- a/native/mediasoup_elixir/src/lib.rs
+++ b/native/mediasoup_elixir/src/lib.rs
@@ -26,9 +26,10 @@ use crate::pipe_transport::{
     pipe_transport_srtp_parameters, pipe_transport_tuple,
 };
 use crate::plain_transport::{
-    plain_transport_close, plain_transport_connect, plain_transport_consume, plain_transport_event,
-    plain_transport_get_stats, plain_transport_id, plain_transport_sctp_parameters,
-    plain_transport_sctp_state, plain_transport_srtp_parameters, plain_transport_tuple,
+    plain_transport_close, plain_transport_closed, plain_transport_connect,
+    plain_transport_consume, plain_transport_event, plain_transport_get_stats, plain_transport_id,
+    plain_transport_sctp_parameters, plain_transport_sctp_state, plain_transport_srtp_parameters,
+    plain_transport_tuple,
 };
 use crate::producer::{
     producer_close, producer_closed, producer_dump, producer_event, producer_get_stats,
@@ -180,6 +181,7 @@ rustler::init! {
         plain_transport_get_stats,
         plain_transport_consume,
         plain_transport_close,
+        plain_transport_closed,
         plain_transport_event,
 
         // consumer


### PR DESCRIPTION
### Linear Ticket
https://linear.app/ovice/issue/WORK-582/add-closed-nif-in-plain-transport

### Description
Regarding RM#37 for room recording:

- When host broadcasts to finish recording, each user inside the room will need to close their own plain transport, in order to do that, they will use the plain transport `pid` to close it, but since plain transport `pid` will be found alive, [this condition](https://github.com/oviceinc/mediasoup-elixir/blob/main/lib/plain_transport.ex#L147) which is devided in 2, pass the left side (as it's already alive) and check the right one (closed?).
- closed? call exists in plain transport.ex but isn't referenced to any nif with the module, so this PR's purpose is to add the missing closed? nif reference in ex module in order to link it to its appropriate one in rust.

:warning: this situation (closed? nif correspondence) is also missing in [webrtc transport](https://github.com/oviceinc/mediasoup-elixir/blob/main/lib/webrtc_transport.ex#L325) and [pipe transports](https://github.com/oviceinc/mediasoup-elixir/blob/main/lib/pipe_transport.ex#L248) both, so we can probably add them later in case we want to use them someday and so that we don't run into an exception.