### PR TITLE
Create a WorkerManager for each Worker

### DIFF
--- a/native/mediasoup_elixir/src/task.rs
+++ b/native/mediasoup_elixir/src/task.rs
@@ -1,6 +1,5 @@
 use async_executor::{Executor, Task};
 use futures_lite::future;
-use mediasoup::worker_manager::WorkerManager;
 use once_cell::sync::Lazy;
 use std::future::Future;
 use std::sync::Arc;
@@ -15,20 +14,6 @@ static EXECUTOR: Lazy<Arc<Executor<'static>>> = Lazy::new(|| {
     executor
 });
 
-static WORKER_MANAGER: Lazy<Arc<WorkerManager>> = Lazy::new(|| {
-    let executor = Arc::new(Executor::new());
-    let thread_count = std::cmp::max(2, num_cpus::get());
-
-    for _ in 0..thread_count {
-        create_thread_for_executor(Arc::clone(&executor), "ex-mediasoup-wm".into());
-    }
-
-    Arc::new(WorkerManager::with_executor(executor))
-});
-
-pub fn worker_manager() -> Arc<WorkerManager> {
-    WORKER_MANAGER.clone()
-}
 pub fn executor() -> Arc<Executor<'static>> {
     EXECUTOR.clone()
 }

--- a/native/mediasoup_elixir/src/worker.rs
+++ b/native/mediasoup_elixir/src/worker.rs
@@ -1,11 +1,11 @@
 use crate::atoms;
 use crate::json_serde::JsonSerdeWrap;
 use crate::router::RouterOptionsStruct;
-use crate::task;
 use crate::{send_async_nif_result, send_msg_from_other_thread, RouterRef, WorkerRef};
 use mediasoup::worker::{
     WorkerDtlsFiles, WorkerId, WorkerLogLevel, WorkerLogTag, WorkerSettings, WorkerUpdateSettings,
 };
+use mediasoup::worker_manager::WorkerManager;
 use rustler::{Env, Error, NifResult, NifStruct, ResourceArc};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -127,7 +127,7 @@ fn create_worker_impl(
     settings: WorkerSettings,
 ) -> NifResult<(rustler::Atom, rustler::Atom)> {
     send_async_nif_result(env, async move {
-        let worker_manager = task::worker_manager();
+        let worker_manager = WorkerManager::new();
         worker_manager
             .create_worker(settings)
             .await

--- a/test/integration/test_util.ex
+++ b/test/integration/test_util.ex
@@ -28,7 +28,7 @@ defmodule Mediasoup.TestUtil do
           assert_receive {:DOWN, ^ref, _, _, _}, 1000
         end
 
-        Process.sleep(1)
+        Process.sleep(10)
         assert Mediasoup.Worker.worker_count() === 0
       end)
     end


### PR DESCRIPTION
To destroy the possibility that the response is deteriorating because the thread pool is stuck.