### PR TITLE
Disable precompile on Apple chip mac

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule MediasoupElixir.MixProject do
   use Mix.Project
 
-  @version "0.7.0"
+  @version "0.7.1"
   @repo "https://github.com/oviceinc/mediasoup-elixir"
   @description """
   Elixir wrapper for mediasoup


### PR DESCRIPTION
Because cross compile between arm64 and x86_64 on macOS doesn't work. Build passes, but no symbols and error at runtime

Github actions only has x86_64 mac, so we can't native build on arm64 mac