### PR TITLE
prebuilt for apple chip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,7 @@ jobs:
               use-cross: true,
               cross-version: "from-source",
             }
-            # we can't cross build for aarch64 on intel mac for now
-          #- { target: aarch64-apple-darwin, os: macos-11 }
+          - { target: aarch64-apple-darwin, os: macos-14 }
           - {
               target: riscv64gc-unknown-linux-gnu,
               os: ubuntu-20.04,

--- a/lib/nif.ex
+++ b/lib/nif.ex
@@ -9,7 +9,7 @@ defmodule Mediasoup.Nif do
     def prebuild_targets() do
       # Anything that is difficult to prebuilt in cross compile is excluded for now.
       [
-        #  "aarch64-apple-darwin",
+        "aarch64-apple-darwin",
         "aarch64-unknown-linux-gnu",
         "aarch64-unknown-linux-musl",
         "arm-unknown-linux-gnueabihf",


### PR DESCRIPTION
https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/
