### PR TITLE
Mediasoup rust 0.13.0

### DIFF
--- a/lib/mediasoup.ex
+++ b/lib/mediasoup.ex
@@ -14,4 +14,14 @@ defmodule Mediasoup do
   @type num_sctp_streams :: %{OS: integer(), MIS: integer()}
   @typedoc "https://mediasoup.org/documentation/v3/mediasoup/api/#TransportListenIp"
   @type transport_listen_ip :: %{:ip => String.t(), optional(:announcedIp) => String.t() | nil}
+
+  @typedoc "https://mediasoup.org/documentation/v3/mediasoup/api/#TransportListenInfo"
+  @type transport_listen_info :: %{
+          :ip => String.t(),
+          :protocol => :tcp | :udp,
+          optional(:announcedIp) => String.t() | nil,
+          optional(:port) => integer(),
+          optional(:sendBufferSize) => integer(),
+          optional(:recvBufferSize) => integer()
+        }
 end

--- a/lib/pipe_transport.ex
+++ b/lib/pipe_transport.ex
@@ -28,7 +28,9 @@ defmodule Mediasoup.PipeTransport do
 
     @type t :: %Options{
             listen_info: Mediasoup.transport_listen_info() | nil,
+            # deprecated use listen_info instead
             listen_ip: Mediasoup.transport_listen_ip() | nil,
+            # deprecated use listen_info instead
             port: integer() | nil,
             enable_sctp: boolean | nil,
             num_sctp_streams: Mediasoup.num_sctp_streams() | nil,

--- a/lib/pipe_transport.ex
+++ b/lib/pipe_transport.ex
@@ -15,20 +15,20 @@ defmodule Mediasoup.PipeTransport do
     https://mediasoup.org/documentation/v3/mediasoup/api/#PipeTransportOptions
     """
 
-    @enforce_keys [:listen_ip]
-    defstruct [
-      :listen_ip,
-      port: nil,
-      enable_sctp: nil,
-      num_sctp_streams: nil,
-      max_sctp_message_size: nil,
-      sctp_send_buffer_size: nil,
-      enable_rtx: nil,
-      enable_srtp: nil
-    ]
+    @enforce_keys []
+    defstruct listen_ip: nil,
+              listen_info: nil,
+              port: nil,
+              enable_sctp: nil,
+              num_sctp_streams: nil,
+              max_sctp_message_size: nil,
+              sctp_send_buffer_size: nil,
+              enable_rtx: nil,
+              enable_srtp: nil
 
     @type t :: %Options{
-            listen_ip: Mediasoup.transport_listen_ip(),
+            listen_info: Mediasoup.transport_listen_info() | nil,
+            listen_ip: Mediasoup.transport_listen_ip() | nil,
             port: integer() | nil,
             enable_sctp: boolean | nil,
             num_sctp_streams: Mediasoup.num_sctp_streams() | nil,
@@ -37,6 +37,22 @@ defmodule Mediasoup.PipeTransport do
             enable_rtx: boolean | nil,
             enable_srtp: boolean | nil
           }
+    def normalize(%Options{listen_ip: listen_ip, port: port} = option)
+        when not is_nil(listen_ip) do
+      normalize(%Options{
+        option
+        | listen_ip: nil,
+          port: nil,
+          listen_info: %{
+            protocol: "udp",
+            ip: listen_ip.ip,
+            announcedIp: listen_ip[:announcedIp],
+            port: port
+          }
+      })
+    end
+
+    def normalize(%Options{} = option), do: option
   end
 
   @typedoc """

--- a/lib/plain_transport.ex
+++ b/lib/plain_transport.ex
@@ -30,7 +30,9 @@ defmodule Mediasoup.PlainTransport do
 
     @type t :: %Options{
             listen_info: Mediasoup.transport_listen_info() | nil,
+            # deprecated use listen_info instead
             listen_ip: Mediasoup.transport_listen_ip() | nil,
+            # deprecated use listen_info instead
             port: integer() | nil,
             rtcp_mux: boolean | nil,
             comedia: boolean | nil,
@@ -45,6 +47,7 @@ defmodule Mediasoup.PlainTransport do
       map = for {key, val} <- map, into: %{}, do: {to_string(key), val}
 
       %Options{
+        listen_info: map["listenInfo"],
         listen_ip: map["listenIp"],
         port: map["port"],
         rtcp_mux: map["rtcpMux"],

--- a/lib/plain_transport.ex
+++ b/lib/plain_transport.ex
@@ -16,21 +16,21 @@ defmodule Mediasoup.PlainTransport do
     https://mediasoup.org/documentation/v3/mediasoup/api/#PlainTransportOptions
     """
 
-    @enforce_keys [:listen_ip]
-    defstruct [
-      :listen_ip,
-      port: nil,
-      rtcp_mux: nil,
-      comedia: nil,
-      enable_sctp: nil,
-      num_sctp_streams: nil,
-      max_sctp_message_size: nil,
-      sctp_send_buffer_size: nil,
-      enable_srtp: nil
-    ]
+    @enforce_keys []
+    defstruct listen_ip: nil,
+              listen_info: nil,
+              port: nil,
+              rtcp_mux: nil,
+              comedia: nil,
+              enable_sctp: nil,
+              num_sctp_streams: nil,
+              max_sctp_message_size: nil,
+              sctp_send_buffer_size: nil,
+              enable_srtp: nil
 
     @type t :: %Options{
-            listen_ip: Mediasoup.transport_listen_ip(),
+            listen_info: Mediasoup.transport_listen_info() | nil,
+            listen_ip: Mediasoup.transport_listen_ip() | nil,
             port: integer() | nil,
             rtcp_mux: boolean | nil,
             comedia: boolean | nil,
@@ -56,6 +56,23 @@ defmodule Mediasoup.PlainTransport do
         enable_srtp: map["enableSrtp"]
       }
     end
+
+    def normalize(%Options{listen_ip: listen_ip, port: port} = option)
+        when not is_nil(listen_ip) do
+      normalize(%Options{
+        option
+        | listen_ip: nil,
+          port: nil,
+          listen_info: %{
+            protocol: "udp",
+            ip: listen_ip.ip,
+            announcedIp: listen_ip[:announcedIp],
+            port: port
+          }
+      })
+    end
+
+    def normalize(%Options{} = option), do: option
   end
 
   @type transport_stat :: map()

--- a/lib/router.ex
+++ b/lib/router.ex
@@ -126,6 +126,7 @@ defmodule Mediasoup.Router do
         %Router{pid: pid},
         %WebRtcTransport.Options{} = option
       ) do
+    option = WebRtcTransport.Options.normalize(option)
     GenServer.call(pid, {:create_webrtc_transport, [option]})
   end
 
@@ -143,6 +144,7 @@ defmodule Mediasoup.Router do
         %Router{pid: pid},
         %Mediasoup.PlainTransport.Options{} = option
       ) do
+    option = Mediasoup.PlainTransport.Options.normalize(option)
     GenServer.call(pid, {:create_plain_transport, [option]})
   end
 
@@ -253,7 +255,7 @@ defmodule Mediasoup.Router do
   https://mediasoup.org/documentation/v3/mediasoup/api/#router-createPipeTransport
   """
   def create_pipe_transport(%Router{pid: pid}, %PipeTransport.Options{} = option) do
-    GenServer.call(pid, {:create_pipe_transport, [option]})
+    GenServer.call(pid, {:create_pipe_transport, [PipeTransport.Options.normalize(option)]})
   end
 
   @spec can_consume?(t, String.t(), rtpCapabilities) :: boolean

--- a/lib/webrtc_transport.ex
+++ b/lib/webrtc_transport.ex
@@ -18,24 +18,33 @@ defmodule Mediasoup.WebRtcTransport do
 
     @enforce_keys []
     defstruct listen_ips: nil,
-              enable_udp: nil,
+              listen_infos: nil,
+              webrtc_server: nil,
+              listen: nil,
+              port: nil,
+              enable_udp: true,
               enable_tcp: nil,
-              prefer_udp: nil,
-              prefer_tcp: nil,
+              prefer_udp: false,
+              prefer_tcp: false,
               initial_available_outgoing_bitrate: nil,
               enable_sctp: nil,
               num_sctp_streams: nil,
               max_sctp_message_size: nil,
-              sctp_send_buffer_size: nil,
-              webrtc_server: nil
+              sctp_send_buffer_size: nil
 
     @type t :: %Options{
             listen_ips: [Mediasoup.transport_listen_ip()] | nil,
+            listen_infos: [Mediasoup.transport_listen_info()] | nil,
             webrtc_server: Mediasoup.WebRtcServer.t() | nil,
-            enable_udp: boolean | nil,
+            listen:
+              [Mediasoup.transport_listen_info()]
+              | Mediasoup.WebRtcServer.t()
+              | nil,
+            port: integer() | nil,
+            enable_udp: boolean,
             enable_tcp: boolean | nil,
-            prefer_udp: boolean | nil,
-            prefer_tcp: boolean | nil,
+            prefer_udp: boolean,
+            prefer_tcp: boolean,
             initial_available_outgoing_bitrate: integer() | nil,
             enable_sctp: boolean | nil,
             num_sctp_streams: Mediasoup.num_sctp_streams() | nil,
@@ -48,17 +57,116 @@ defmodule Mediasoup.WebRtcTransport do
 
       %Options{
         listen_ips: map["listenIps"],
-        enable_udp: map["enableUdp"],
-        enable_tcp: map["enableTcp"],
-        prefer_udp: map["preferUdp"],
-        prefer_tcp: map["preferTcp"],
+        listen_infos: map["listenInfos"],
+        webrtc_server: map["webrtcServer"],
+        listen: map["listen"],
+        enable_udp: Map.get(map, "enableUdp", true),
+        enable_tcp: Map.get(map, "enableTcp", nil),
+        prefer_udp: Map.get(map, "preferUdp", false),
+        prefer_tcp: Map.get(map, "preferTcp", false),
         initial_available_outgoing_bitrate: map["initialAvailableOutgoingBitrate"],
         enable_sctp: map["enableSctp"],
         num_sctp_streams: map["numSctpStreams"],
         max_sctp_message_size: map["maxSctpMessageSize"],
-        sctp_send_buffer_size: map["sctpSendBufferSize"],
-        webrtc_server: map["webrtcServer"]
+        sctp_send_buffer_size: map["sctpSendBufferSize"]
       }
+    end
+
+    defp protocols(%{
+           enable_udp: true,
+           enable_tcp: true,
+           prefer_udp: true
+         }) do
+      [:udp, :tcp]
+    end
+
+    defp protocols(%{
+           enable_udp: true,
+           enable_tcp: true,
+           prefer_tcp: true
+         }) do
+      [:tcp, :udp]
+    end
+
+    defp protocols(%{
+           enable_tcp: true
+         }) do
+      [:tcp]
+    end
+
+    defp protocols(%{
+           enable_udp: true
+         }) do
+      [:udp]
+    end
+
+    defp protocols(_), do: []
+
+    def normalize(
+          %Options{
+            listen_ips: listen_ips,
+            port: port
+          } = option
+        )
+        when not is_nil(listen_ips) do
+      listen_ips =
+        Enum.map(listen_ips, fn listen_ip ->
+          if is_binary(listen_ip) do
+            %{ip: listen_ip}
+          else
+            listen_ip
+          end
+        end)
+
+      # Convert deprecated TransportListenIps to TransportListenInfos.
+      protocols = protocols(option)
+
+      listen_infos =
+        Enum.flat_map(protocols, fn protocol ->
+          Enum.map(listen_ips, fn listen_ip ->
+            %{
+              protocol: protocol,
+              ip: listen_ip.ip,
+              announcedIp: listen_ip[:announcedIp],
+              port: port
+            }
+          end)
+        end)
+
+      normalize(%Options{
+        option
+        | listen_ips: nil,
+          listen_infos: listen_infos
+      })
+    end
+
+    def normalize(
+          %Options{
+            listen: %Mediasoup.WebRtcServer{} = listen
+          } = option
+        ) do
+      normalize(%Options{
+        option
+        | listen: nil,
+          webrtc_server: listen
+      })
+    end
+
+    def normalize(
+          %Options{
+            listen: listen
+          } = option
+        )
+        when not is_nil(listen) do
+      normalize(%Options{
+        option
+        | listen: nil,
+          listen_infos: listen
+      })
+    end
+
+    def normalize(option) do
+      option
     end
   end
 

--- a/lib/webrtc_transport.ex
+++ b/lib/webrtc_transport.ex
@@ -125,8 +125,8 @@ defmodule Mediasoup.WebRtcTransport do
       protocols = protocols(option)
 
       listen_infos =
-        Enum.flat_map(protocols, fn protocol ->
-          Enum.map(listen_ips, fn listen_ip ->
+        Enum.flat_map(listen_ips, fn listen_ip ->
+          Enum.map(protocols, fn protocol ->
             %{
               protocol: protocol,
               ip: listen_ip.ip,

--- a/lib/webrtc_transport.ex
+++ b/lib/webrtc_transport.ex
@@ -33,8 +33,11 @@ defmodule Mediasoup.WebRtcTransport do
               sctp_send_buffer_size: nil
 
     @type t :: %Options{
+            # deprecated use listen instead
             listen_ips: [Mediasoup.transport_listen_ip()] | nil,
+            # deprecated use listen instead
             listen_infos: [Mediasoup.transport_listen_info()] | nil,
+            # deprecated use listen instead
             webrtc_server: Mediasoup.WebRtcServer.t() | nil,
             listen:
               [Mediasoup.transport_listen_info()]

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule MediasoupElixir.MixProject do
   use Mix.Project
 
-  @version "0.7.3"
+  @version "0.8.0"
   @repo "https://github.com/oviceinc/mediasoup-elixir"
   @description """
   Elixir wrapper for mediasoup

--- a/native/mediasoup_elixir/Cargo.toml
+++ b/native/mediasoup_elixir/Cargo.toml
@@ -11,8 +11,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 rustler = { version = "0.30.0", default-features = false, features = ["derive"] }
-mediasoup = "0.12.0"
-mediasoup-sys = ">=0.6.0"
+mediasoup = "0.13.0"
+mediasoup-sys = ">=0.7.0"
 futures-lite = "2.0.0"
 once_cell = "1.18.0"
 num_cpus = "1.16.0"

--- a/native/mediasoup_elixir/src/pipe_transport.rs
+++ b/native/mediasoup_elixir/src/pipe_transport.rs
@@ -6,7 +6,7 @@ use crate::json_serde::JsonSerdeWrap;
 use crate::producer::ProducerOptionsStruct;
 use crate::{atoms, DataConsumerRef, DataProducerRef};
 use crate::{send_async_nif_result, ConsumerRef, PipeTransportRef, ProducerRef};
-use mediasoup::data_structures::{ListenIp, SctpState, TransportTuple};
+use mediasoup::data_structures::{ListenInfo, SctpState, TransportTuple};
 use mediasoup::pipe_transport::{PipeTransportOptions, PipeTransportRemoteParameters};
 use mediasoup::sctp_parameters::SctpParameters;
 use mediasoup::srtp_parameters::SrtpParameters;
@@ -18,9 +18,7 @@ use rustler::{Atom, Env, NifResult, NifStruct, ResourceArc};
 #[module = "Mediasoup.PipeTransport.Options"]
 pub struct PipeTransportOptionsStruct {
     /// Listening IP address.
-    pub listen_ip: JsonSerdeWrap<ListenIp>,
-    /// Fixed port to listen on instead of selecting automatically from Worker's port range.
-    pub port: Option<u16>,
+    pub listen_info: JsonSerdeWrap<ListenInfo>,
     /// Create a SCTP association.
     /// Default false.
     pub enable_sctp: Option<bool>,
@@ -45,9 +43,7 @@ pub struct PipeTransportOptionsStruct {
 
 impl PipeTransportOptionsStruct {
     pub fn try_to_option(self) -> rustler::NifResult<PipeTransportOptions> {
-        let mut option = PipeTransportOptions::new(*self.listen_ip);
-
-        option.port = self.port;
+        let mut option = PipeTransportOptions::new(*self.listen_info);
 
         if let Some(enable_sctp) = self.enable_sctp {
             option.enable_sctp = enable_sctp;

--- a/native/mediasoup_elixir/src/plain_transport.rs
+++ b/native/mediasoup_elixir/src/plain_transport.rs
@@ -5,7 +5,7 @@ use crate::producer::ProducerOptionsStruct;
 use crate::PlainTransportRef;
 use crate::{atoms, send_async_nif_result, ConsumerRef, ProducerRef};
 use mediasoup::consumer::ConsumerOptions;
-use mediasoup::data_structures::{ListenIp, SctpState, TransportTuple};
+use mediasoup::data_structures::{ListenInfo, SctpState, TransportTuple};
 use mediasoup::plain_transport::{PlainTransportOptions, PlainTransportRemoteParameters};
 use mediasoup::prelude::Transport;
 use mediasoup::producer::ProducerOptions;
@@ -17,8 +17,7 @@ use rustler::{Atom, Env, NifResult, NifStruct, ResourceArc};
 #[derive(NifStruct)]
 #[module = "Mediasoup.PlainTransport.Options"]
 pub struct PlainTransportOptionsStruct {
-    pub listen_ip: JsonSerdeWrap<ListenIp>,
-    pub port: Option<u16>,
+    pub listen_info: JsonSerdeWrap<ListenInfo>,
     pub rtcp_mux: Option<bool>,
     pub comedia: Option<bool>,
     pub enable_sctp: Option<bool>,
@@ -29,9 +28,7 @@ pub struct PlainTransportOptionsStruct {
 }
 impl PlainTransportOptionsStruct {
     pub fn try_to_option(&self) -> Result<PlainTransportOptions, &'static str> {
-        let mut option = PlainTransportOptions::new(*self.listen_ip);
-
-        option.port = self.port;
+        let mut option = PlainTransportOptions::new(*self.listen_info);
 
         if let Some(rtcp_mux) = self.rtcp_mux {
             option.rtcp_mux = rtcp_mux;

--- a/native/mediasoup_elixir/src/webrtc_server.rs
+++ b/native/mediasoup_elixir/src/webrtc_server.rs
@@ -1,51 +1,27 @@
 use crate::{atoms, json_serde::JsonSerdeWrap, send_async_nif_result, WebRtcServerRef};
 use mediasoup::{
-    data_structures::Protocol,
-    prelude::{ListenIp, WebRtcServerListenInfo, WebRtcServerListenInfos, WebRtcServerOptions},
+    prelude::{ListenInfo,  WebRtcServerListenInfos, WebRtcServerOptions},
     webrtc_server::WebRtcServerId,
 };
 use rustler::{Atom, Env, NifResult, NifStruct, ResourceArc};
-use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct WebRtcServerListenInfoDeserializable {
-    /// Network protocol.
-    pub protocol: Protocol,
-    /// Listening IP address.
-    #[serde(flatten)]
-    pub listen_ip: ListenIp,
-    /// Listening port.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub port: Option<u16>,
-}
-
-impl WebRtcServerListenInfoDeserializable {
-    pub fn into_info(self) -> WebRtcServerListenInfo {
-        WebRtcServerListenInfo {
-            protocol: self.protocol,
-            listen_ip: self.listen_ip,
-            port: self.port,
-        }
-    }
-}
 
 #[derive(NifStruct)]
 #[module = "Mediasoup.WebRtcServer.Options"]
 pub struct WebRtcServerOptionsStruct {
-    listen_infos: JsonSerdeWrap<Vec<WebRtcServerListenInfoDeserializable>>,
+    listen_infos: JsonSerdeWrap<Vec<ListenInfo>>,
 }
 
 impl WebRtcServerOptionsStruct {
     pub fn try_to_option(&self) -> Result<WebRtcServerOptions, &'static str> {
         let infos = match self.listen_infos.first() {
-            None => Err("Rquired least one ip"),
-            Some(info) => Ok(WebRtcServerListenInfos::new(info.into_info())),
+            None => Err("Rquired least one listen info"),
+            Some(info) => Ok(WebRtcServerListenInfos::new(*info)),
         }?;
 
         let infos = self.listen_infos[1..]
             .iter()
-            .fold(infos, |infos, info| infos.insert(info.into_info()));
+            .fold(infos, |infos, info| infos.insert(*info));
 
         Ok(WebRtcServerOptions::new(infos))
     }

--- a/native/mediasoup_elixir/src/webrtc_server.rs
+++ b/native/mediasoup_elixir/src/webrtc_server.rs
@@ -1,10 +1,9 @@
 use crate::{atoms, json_serde::JsonSerdeWrap, send_async_nif_result, WebRtcServerRef};
 use mediasoup::{
-    prelude::{ListenInfo,  WebRtcServerListenInfos, WebRtcServerOptions},
+    prelude::{ListenInfo, WebRtcServerListenInfos, WebRtcServerOptions},
     webrtc_server::WebRtcServerId,
 };
 use rustler::{Atom, Env, NifResult, NifStruct, ResourceArc};
-
 
 #[derive(NifStruct)]
 #[module = "Mediasoup.WebRtcServer.Options"]

--- a/native/mediasoup_elixir/src/webrtc_transport.rs
+++ b/native/mediasoup_elixir/src/webrtc_transport.rs
@@ -351,7 +351,9 @@ impl WebRtcTransportOptionsStruct {
                 Some(ip) => Ok(WebRtcTransportListenInfos::new(*ip)),
             }?;
 
-            let infos = listen_infos[1..].iter().fold(infos, |infos, ip| infos.insert(*ip));
+            let infos = listen_infos[1..]
+                .iter()
+                .fold(infos, |infos, ip| infos.insert(*ip));
 
             Ok(WebRtcTransportOptions::new(infos))
         } else {

--- a/test/integration/test_webrtc_transport.ex
+++ b/test/integration/test_webrtc_transport.ex
@@ -109,6 +109,18 @@ defmodule IntegrateTest.WebRtcTransportTest do
                  "type" => "host"
                },
                %{
+                 "foundation" => "udpcandidate",
+                 "ip" => "9.9.9.2",
+                 "protocol" => "udp",
+                 "type" => "host"
+               },
+               %{
+                 "foundation" => "udpcandidate",
+                 "ip" => "127.0.0.1",
+                 "protocol" => "udp",
+                 "type" => "host"
+               },
+               %{
                  "foundation" => "tcpcandidate",
                  "ip" => "9.9.9.1",
                  "protocol" => "tcp",
@@ -116,22 +128,10 @@ defmodule IntegrateTest.WebRtcTransportTest do
                  "type" => "host"
                },
                %{
-                 "foundation" => "udpcandidate",
-                 "ip" => "9.9.9.2",
-                 "protocol" => "udp",
-                 "type" => "host"
-               },
-               %{
                  "foundation" => "tcpcandidate",
                  "ip" => "9.9.9.2",
                  "protocol" => "tcp",
                  "tcpType" => "passive",
-                 "type" => "host"
-               },
-               %{
-                 "foundation" => "udpcandidate",
-                 "ip" => "127.0.0.1",
-                 "protocol" => "udp",
                  "type" => "host"
                },
                %{
@@ -167,9 +167,9 @@ defmodule IntegrateTest.WebRtcTransportTest do
     ] = ice_candidates
 
     assert priority1 > priority2
-    assert priority3 > priority2
+    assert priority2 > priority3
     assert priority3 > priority4
-    assert priority5 > priority4
+    assert priority4 > priority5
     assert priority5 > priority6
 
     assert "new" == WebRtcTransport.ice_state(transport1)

--- a/test/integration/test_webrtc_transport.ex
+++ b/test/integration/test_webrtc_transport.ex
@@ -109,18 +109,6 @@ defmodule IntegrateTest.WebRtcTransportTest do
                  "type" => "host"
                },
                %{
-                 "foundation" => "udpcandidate",
-                 "ip" => "9.9.9.2",
-                 "protocol" => "udp",
-                 "type" => "host"
-               },
-               %{
-                 "foundation" => "udpcandidate",
-                 "ip" => "127.0.0.1",
-                 "protocol" => "udp",
-                 "type" => "host"
-               },
-               %{
                  "foundation" => "tcpcandidate",
                  "ip" => "9.9.9.1",
                  "protocol" => "tcp",
@@ -128,10 +116,22 @@ defmodule IntegrateTest.WebRtcTransportTest do
                  "type" => "host"
                },
                %{
+                 "foundation" => "udpcandidate",
+                 "ip" => "9.9.9.2",
+                 "protocol" => "udp",
+                 "type" => "host"
+               },
+               %{
                  "foundation" => "tcpcandidate",
                  "ip" => "9.9.9.2",
                  "protocol" => "tcp",
                  "tcpType" => "passive",
+                 "type" => "host"
+               },
+               %{
+                 "foundation" => "udpcandidate",
+                 "ip" => "127.0.0.1",
+                 "protocol" => "udp",
                  "type" => "host"
                },
                %{

--- a/test/webrtc_transport_test.exs
+++ b/test/webrtc_transport_test.exs
@@ -42,6 +42,26 @@ defmodule MediasoupElixirWebRtcTransportTest do
                prefer_tcp: false,
                enable_tcp: true
              })
+
+    assert %Options{
+             listen_infos: [
+               %{ip: "127.0.0.1", announcedIp: nil, port: nil, protocol: :udp},
+               %{announcedIp: nil, ip: "127.0.0.1", port: nil, protocol: :tcp}
+             ]
+           } =
+             Options.normalize(%Options{
+               listen: [
+                 %{ip: "127.0.0.1", announcedIp: nil, port: nil, protocol: :udp},
+                 %{announcedIp: nil, ip: "127.0.0.1", port: nil, protocol: :tcp}
+               ]
+             })
+
+    assert %Options{
+             webrtc_server: %Mediasoup.WebRtcServer{id: "test"}
+           } =
+             Options.normalize(%Options{
+               listen: %Mediasoup.WebRtcServer{id: "test"}
+             })
   end
 
   test "create_succeeds", %{worker: worker} do

--- a/test/webrtc_transport_test.exs
+++ b/test/webrtc_transport_test.exs
@@ -29,7 +29,7 @@ defmodule MediasoupElixirWebRtcTransportTest do
     assert %Options{
              listen_infos: [
                %{ip: "127.0.0.1", announcedIp: nil, port: nil, protocol: :udp},
-               %{announcedIp: nil, ip: "127.0.0.1", port: nil, protocol: :tcp}
+               %{ip: "127.0.0.1", announcedIp: nil, port: nil, protocol: :tcp}
              ]
            } =
              Options.normalize(%Options{
@@ -46,14 +46,32 @@ defmodule MediasoupElixirWebRtcTransportTest do
     assert %Options{
              listen_infos: [
                %{ip: "127.0.0.1", announcedIp: nil, port: nil, protocol: :udp},
-               %{announcedIp: nil, ip: "127.0.0.1", port: nil, protocol: :tcp}
+               %{ip: "127.0.0.1", announcedIp: nil, port: nil, protocol: :tcp}
              ]
            } =
              Options.normalize(%Options{
                listen: [
                  %{ip: "127.0.0.1", announcedIp: nil, port: nil, protocol: :udp},
-                 %{announcedIp: nil, ip: "127.0.0.1", port: nil, protocol: :tcp}
+                 %{ip: "127.0.0.1", announcedIp: nil, port: nil, protocol: :tcp}
                ]
+             })
+
+    assert %Options{
+             listen_infos: [
+               %{ip: "127.0.0.1", announcedIp: nil, port: nil, protocol: :tcp},
+               %{ip: "127.0.0.1", announcedIp: nil, port: nil, protocol: :udp}
+             ]
+           } =
+             Options.normalize(%Options{
+               listen_ips: [
+                 %{
+                   ip: "127.0.0.1"
+                 }
+               ],
+               prefer_udp: false,
+               prefer_tcp: true,
+               enable_udp: true,
+               enable_tcp: true
              })
 
     assert %Options{
@@ -61,6 +79,47 @@ defmodule MediasoupElixirWebRtcTransportTest do
            } =
              Options.normalize(%Options{
                listen: %Mediasoup.WebRtcServer{id: "test"}
+             })
+
+    assert %Options{
+             listen_infos: []
+           } =
+             Options.normalize(%Options{
+               listen_ips: [
+                 %{
+                   ip: "127.0.0.1"
+                 }
+               ],
+               prefer_udp: true,
+               prefer_tcp: false,
+               enable_tcp: false,
+               enable_udp: false
+             })
+
+    assert %Options{
+             listen_infos: [
+               %{announcedIp: nil, ip: "127.0.0.1", port: nil, protocol: :tcp}
+             ]
+           } =
+             Options.normalize(%Options{
+               listen_ips: [
+                 %{
+                   ip: "127.0.0.1"
+                 }
+               ],
+               enable_tcp: true,
+               enable_udp: false
+             })
+
+    assert %Options{
+             listen_infos: [
+               %{announcedIp: nil, ip: "127.0.0.1", port: nil, protocol: :tcp}
+             ]
+           } =
+             Options.normalize(%Options{
+               listen_ips: ["127.0.0.1"],
+               enable_tcp: true,
+               enable_udp: false
              })
   end
 

--- a/test/webrtc_transport_test.exs
+++ b/test/webrtc_transport_test.exs
@@ -10,6 +10,40 @@ defmodule MediasoupElixirWebRtcTransportTest do
     %{worker: worker}
   end
 
+  test "normalize option" do
+    alias Mediasoup.WebRtcTransport.Options
+
+    assert %Options{
+             listen_infos: [%{ip: "127.0.0.1", announcedIp: nil, port: nil, protocol: :udp}]
+           } =
+             Options.normalize(
+               Options.from_map(%{
+                 listenIps: [
+                   %{
+                     ip: "127.0.0.1"
+                   }
+                 ]
+               })
+             )
+
+    assert %Options{
+             listen_infos: [
+               %{ip: "127.0.0.1", announcedIp: nil, port: nil, protocol: :udp},
+               %{announcedIp: nil, ip: "127.0.0.1", port: nil, protocol: :tcp}
+             ]
+           } =
+             Options.normalize(%Options{
+               listen_ips: [
+                 %{
+                   ip: "127.0.0.1"
+                 }
+               ],
+               prefer_udp: true,
+               prefer_tcp: false,
+               enable_tcp: true
+             })
+  end
+
   test "create_succeeds", %{worker: worker} do
     IntegrateTest.WebRtcTransportTest.create_succeeds(worker)
   end


### PR DESCRIPTION
listen_ips is now deprecated and changed to listen_infos.