### PR TITLE
Fix cross compile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,12 +28,13 @@ jobs:
               use-cross: true,
               cross-version: "from-source",
             }
-          - {
-              target: aarch64-unknown-linux-musl,
-              os: ubuntu-20.04,
-              use-cross: true,
-              cross-version: "from-source",
-            }
+          #　mediasoup won't pass build with musl now. https://github.com/versatica/mediasoup/issues/1223
+          #- {
+          #    target: aarch64-unknown-linux-musl,
+          #    os: ubuntu-20.04,
+          #    use-cross: true,
+          #    cross-version: "from-source",
+          #  }
             # we can't cross build for aarch64 on intel mac for now
           #- { target: aarch64-apple-darwin, os: macos-11 }
           - {
@@ -44,12 +45,12 @@ jobs:
             }
           - { target: x86_64-apple-darwin, os: macos-11 }
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04 }
-          - {
-              target: x86_64-unknown-linux-musl,
-              os: ubuntu-20.04,
-              use-cross: true,
-              cross-version: "from-source",
-            }
+          #- {
+          #    target: x86_64-unknown-linux-musl,
+          #    os: ubuntu-20.04,
+          #    use-cross: true,
+          #    cross-version: "from-source",
+          #  }
     # Disabled for now because of build errors on windows
     #      - { target: x86_64-pc-windows-gnu, os: windows-2022 }
     #      - { target: x86_64-pc-windows-msvc, os: windows-2022 }

--- a/lib/nif.ex
+++ b/lib/nif.ex
@@ -11,14 +11,16 @@ defmodule Mediasoup.Nif do
       [
         #  "aarch64-apple-darwin",
         "aarch64-unknown-linux-gnu",
-        "aarch64-unknown-linux-musl",
+        # 　mediasoup won't pass build with musl now. https://github.com/versatica/mediasoup/issues/1223
+        #        "aarch64-unknown-linux-musl",
         "arm-unknown-linux-gnueabihf",
         "riscv64gc-unknown-linux-gnu",
         "x86_64-apple-darwin",
         #    "x86_64-pc-windows-gnu",
         #    "x86_64-pc-windows-msvc",
-        "x86_64-unknown-linux-gnu",
-        "x86_64-unknown-linux-musl"
+        "x86_64-unknown-linux-gnu"
+        # 　mediasoup won't pass build with musl now. https://github.com/versatica/mediasoup/issues/1223
+        #        "x86_64-unknown-linux-musl"
       ]
     end
 

--- a/native/mediasoup_elixir/cross/Dockerfile
+++ b/native/mediasoup_elixir/cross/Dockerfile
@@ -8,21 +8,24 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         wget
 
 
-RUN printf '%s\n' "[binaries]"\
- "c = '${CROSS_TOOLCHAIN_PREFIX}gcc${CROSS_TOOLCHAIN_SUFFIX}'" \
- "cpp = '${CROSS_TOOLCHAIN_PREFIX}g++'" \
- "ar = '${CROSS_TOOLCHAIN_PREFIX}ar'" \
- "strip = '${CROSS_TOOLCHAIN_PREFIX}strip'" \
- "pkg-config = '${PKG_CONFIG_PATH}'" \
- "[properties]" \
-  "sys_root = '${CROSS_SYSROOT}'" \
-  "cmake_toolchain_file = '/opt/toolchain.cmake'" \
- "[host_machine]" \
- "system = 'linux'" \
- "cpu_family = '${CROSS_CMAKE_SYSTEM_PROCESSOR}'" \
- "cpu = '${CROSS_CMAKE_SYSTEM_PROCESSOR}'" \
- "endian = 'little'" \
- > /opt/meson_toolchain.txt
+RUN echo "[constants]\n\
+target_runner = `(python3 -c "print('${CROSS_TARGET_RUNNER}'.split())")`\n\
+[binaries]\n\
+ c = '${CROSS_TOOLCHAIN_PREFIX}gcc${CROSS_TOOLCHAIN_SUFFIX}'\n\
+ cpp = '${CROSS_TOOLCHAIN_PREFIX}g++'\n\
+ ar = '${CROSS_TOOLCHAIN_PREFIX}ar'\n\
+ strip = '${CROSS_TOOLCHAIN_PREFIX}strip'\n\
+ pkg-config = '${PKG_CONFIG_PATH}'\n\
+ exe_wrapper = target_runner\n\
+ [properties]\n\
+ sys_root = '${CROSS_SYSROOT}'\n\
+  cmake_toolchain_file = '/opt/toolchain.cmake'\n\
+ [host_machine]\n\
+ system = 'linux'\n\
+ cpu_family = '${CROSS_CMAKE_SYSTEM_PROCESSOR}'\n\
+ cpu = '${CROSS_CMAKE_SYSTEM_PROCESSOR}'\n\
+ endian = 'little'" > /opt/meson_toolchain.txt
+
 
 ENV MESON_ARGS="--cross-file /opt/meson_toolchain.txt"
 # mediasoup-rust needs CXX environment variables to link C++ standard libraries.


### PR DESCRIPTION
https://github.com/oviceinc/mediasoup-elixir/actions/runs/7319896562/job/19938303196

* Specify `exe_wrapper ` in meson's cross_file
* Drop musl build because mediasoup cannot be built with musl. https://github.com/versatica/mediasoup/issues/1223#issuecomment-1815411159
