### PR TITLE
Fix listen ip conversion

### DIFF
--- a/lib/mediasoup.ex
+++ b/lib/mediasoup.ex
@@ -13,15 +13,8 @@ defmodule Mediasoup do
   @typedoc "https://mediasoup.org/documentation/v3/mediasoup/sctp-parameters/#NumSctpStreams"
   @type num_sctp_streams :: %{OS: integer(), MIS: integer()}
   @typedoc "https://mediasoup.org/documentation/v3/mediasoup/api/#TransportListenIp"
-  @type transport_listen_ip :: %{:ip => String.t(), optional(:announcedIp) => String.t() | nil}
+  @type transport_listen_ip :: Mediasoup.TransportListenInfo.listen_ip()
 
   @typedoc "https://mediasoup.org/documentation/v3/mediasoup/api/#TransportListenInfo"
-  @type transport_listen_info :: %{
-          :ip => String.t(),
-          :protocol => :tcp | :udp,
-          optional(:announcedIp) => String.t() | nil,
-          optional(:port) => integer(),
-          optional(:sendBufferSize) => integer(),
-          optional(:recvBufferSize) => integer()
-        }
+  @type transport_listen_info :: Mediasoup.TransportListenInfo.t()
 end

--- a/lib/pipe_transport.ex
+++ b/lib/pipe_transport.ex
@@ -2,7 +2,17 @@ defmodule Mediasoup.PipeTransport do
   @moduledoc """
   https://mediasoup.org/documentation/v3/mediasoup/api/#PipeTransport
   """
-  alias Mediasoup.{PipeTransport, Consumer, DataConsumer, Producer, DataProducer, NifWrap, Nif}
+  alias Mediasoup.{
+    TransportListenInfo,
+    PipeTransport,
+    Consumer,
+    DataConsumer,
+    Producer,
+    DataProducer,
+    NifWrap,
+    Nif
+  }
+
   require NifWrap
   use GenServer, restart: :temporary
 
@@ -41,16 +51,13 @@ defmodule Mediasoup.PipeTransport do
           }
     def normalize(%Options{listen_ip: listen_ip, port: port} = option)
         when not is_nil(listen_ip) do
+      listen_info = TransportListenInfo.create(listen_ip, "udp", port)
+
       normalize(%Options{
         option
         | listen_ip: nil,
           port: nil,
-          listen_info: %{
-            protocol: "udp",
-            ip: listen_ip.ip,
-            announcedIp: listen_ip[:announcedIp],
-            port: port
-          }
+          listen_info: listen_info
       })
     end
 

--- a/lib/plain_transport.ex
+++ b/lib/plain_transport.ex
@@ -3,7 +3,7 @@ defmodule Mediasoup.PlainTransport do
   https://mediasoup.org/documentation/v3/mediasoup/api/#PlainTransport
   """
 
-  alias Mediasoup.{PlainTransport, Consumer, Producer, NifWrap, Nif}
+  alias Mediasoup.{TransportListenInfo, PlainTransport, Consumer, Producer, NifWrap, Nif}
   require NifWrap
   use GenServer, restart: :temporary
 
@@ -29,7 +29,7 @@ defmodule Mediasoup.PlainTransport do
               enable_srtp: nil
 
     @type t :: %Options{
-            listen_info: Mediasoup.transport_listen_info() | nil,
+            listen_info: TransportListenInfo.t() | nil,
             # deprecated use listen_info instead
             listen_ip: Mediasoup.transport_listen_ip() | nil,
             # deprecated use listen_info instead
@@ -62,16 +62,13 @@ defmodule Mediasoup.PlainTransport do
 
     def normalize(%Options{listen_ip: listen_ip, port: port} = option)
         when not is_nil(listen_ip) do
+      listen_info = TransportListenInfo.create(listen_ip, "udp", port)
+
       normalize(%Options{
         option
         | listen_ip: nil,
           port: nil,
-          listen_info: %{
-            protocol: "udp",
-            ip: listen_ip.ip,
-            announcedIp: listen_ip[:announcedIp],
-            port: port
-          }
+          listen_info: listen_info
       })
     end
 

--- a/lib/transport_listen_info.ex
+++ b/lib/transport_listen_info.ex
@@ -1,0 +1,47 @@
+defmodule Mediasoup.TransportListenInfo do
+  @moduledoc """
+  https://mediasoup.org/documentation/v3/mediasoup/api/#TransportListenInfo
+  """
+
+  @typedoc "https://mediasoup.org/documentation/v3/mediasoup/api/#TransportListenIp"
+  @type listen_ip :: %{:ip => String.t(), optional(:announcedIp) => String.t() | nil}
+
+  @typedoc "https://mediasoup.org/documentation/v3/mediasoup/api/#TransportListenInfo"
+  @type t :: %{
+          :ip => String.t(),
+          :protocol => :tcp | :udp,
+          optional(:announcedIp) => String.t() | nil,
+          optional(:port) => integer(),
+          optional(:sendBufferSize) => integer(),
+          optional(:recvBufferSize) => integer()
+        }
+
+  @enforce_keys [:ip, :protocol]
+
+  defstruct [:ip, :protocol, :announcedIp, :port, :sendBufferSize, :recvBufferSize]
+
+  def normalize_listen_ip(ip) when is_binary(ip) do
+    %{:ip => ip}
+  end
+
+  def normalize_listen_ip(%{ip: _} = ip) do
+    ip
+  end
+
+  def create(ip, protocol) do
+    listen_ip = normalize_listen_ip(ip)
+    struct(__MODULE__, Map.merge(listen_ip, %{:protocol => protocol}))
+  end
+
+  def create(ip, protocol, port) do
+    listen_ip = normalize_listen_ip(ip)
+
+    struct(
+      __MODULE__,
+      Map.merge(listen_ip, %{
+        :protocol => protocol,
+        :port => port
+      })
+    )
+  end
+end

--- a/lib/webrtc_transport.ex
+++ b/lib/webrtc_transport.ex
@@ -3,7 +3,17 @@ defmodule Mediasoup.WebRtcTransport do
   https://mediasoup.org/documentation/v3/mediasoup/api/#WebRtcTransport
   """
 
-  alias Mediasoup.{WebRtcTransport, Consumer, Producer, NifWrap, Nif, DataConsumer, DataProducer}
+  alias Mediasoup.{
+    TransportListenInfo,
+    WebRtcTransport,
+    Consumer,
+    Producer,
+    NifWrap,
+    Nif,
+    DataConsumer,
+    DataProducer
+  }
+
   require NifWrap
   use GenServer, restart: :temporary
 
@@ -112,14 +122,7 @@ defmodule Mediasoup.WebRtcTransport do
           } = option
         )
         when not is_nil(listen_ips) do
-      listen_ips =
-        Enum.map(listen_ips, fn listen_ip ->
-          if is_binary(listen_ip) do
-            %{ip: listen_ip}
-          else
-            listen_ip
-          end
-        end)
+      listen_ips = Enum.map(listen_ips, &TransportListenInfo.normalize_listen_ip/1)
 
       # Convert deprecated TransportListenIps to TransportListenInfos.
       protocols = protocols(option)

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule MediasoupElixir.MixProject do
   use Mix.Project
 
-  @version "0.9.0"
+  @version "0.9.1"
   @repo "https://github.com/oviceinc/mediasoup-elixir"
   @description """
   Elixir wrapper for mediasoup

--- a/test/transport_listen_info_test.exs
+++ b/test/transport_listen_info_test.exs
@@ -1,0 +1,16 @@
+defmodule Mediasoup.TransportListenInfoTest do
+  use ExUnit.Case
+
+  alias Mediasoup.TransportListenInfo
+
+  test "create" do
+    assert %Mediasoup.TransportListenInfo{announcedIp: "1.1.1.1", ip: "127.0.0.1", protocol: :udp} ==
+             TransportListenInfo.create(
+               %{ip: "127.0.0.1", announcedIp: "1.1.1.1"},
+               :udp
+             )
+
+    assert %Mediasoup.TransportListenInfo{ip: "127.0.0.1", protocol: :tcp} ==
+             TransportListenInfo.create("127.0.0.1", :tcp)
+  end
+end


### PR DESCRIPTION
`listen_ip` was able to pass a map or string, but omitted to take it into account when converting it to `listen_info`