### PR TITLE
BREAKING CHANGE: Change in log output method

### DIFF
--- a/lib/logger_proxy.ex
+++ b/lib/logger_proxy.ex
@@ -1,0 +1,82 @@
+defmodule Mediasoup.LoggerProxy do
+  @moduledoc """
+  Proxy rust layer logs to elixir logger
+
+  Usage:
+  ```
+    defmodule MyApp.App do
+      use Application
+
+      def start(_type, _args) do
+        children = [
+          { Mediasoup.LoggerProxy, max_level: :info }
+          # ..other children..
+        ]
+        Supervisor.start_link(children, strategy: :one_for_one, name: MyApp.Supervisor)
+      end
+    end
+  ```
+
+  """
+
+  require Logger
+  use GenServer
+
+  defmodule Record do
+    @moduledoc """
+    Struct of log record
+    """
+
+    defstruct [
+      :level,
+      :target,
+      :module_path,
+      :file,
+      :line,
+      :body
+    ]
+
+    @type t :: %__MODULE__{
+            level: :error | :warn | :info | :debug,
+            target: String.t(),
+            module_path: String.t() | nil,
+            file: String.t() | nil,
+            line: integer() | nil,
+            body: String.t()
+          }
+  end
+
+  @type config :: {:max_level, :off | :error | :warn | :info | :debug}
+
+  @spec start_link([config]) :: :ignore | {:error, any} | {:ok, pid}
+  def start_link(config \\ []) do
+    max_level = Keyword.get(config, :max_level, :error)
+    GenServer.start_link(Mediasoup.LoggerProxy, %{max_level: max_level}, name: __MODULE__)
+  end
+
+  def init(init_arg) do
+    Mediasoup.Nif.set_logger_proxy_process(self(), init_arg[:max_level])
+    {:ok, %{}}
+  end
+
+  def handle_info(%Mediasoup.LoggerProxy.Record{} = msg, state) do
+    Logger.log(msg.level, msg.body, %{
+      line: msg.line,
+      file: msg.file,
+      mfa: msg.target,
+      module_path: msg.module_path
+    })
+
+    {:noreply, state}
+  end
+
+  def child_spec(opts) do
+    %{
+      id: Mediasoup.LoggerProxy,
+      start: {__MODULE__, :start_link, [opts]},
+      shutdown: 5_000,
+      restart: :permanent,
+      type: :worker
+    }
+  end
+end

--- a/lib/mediasoup.ex
+++ b/lib/mediasoup.ex
@@ -17,4 +17,12 @@ defmodule Mediasoup do
 
   @typedoc "https://mediasoup.org/documentation/v3/mediasoup/api/#TransportListenInfo"
   @type transport_listen_info :: Mediasoup.TransportListenInfo.t()
+
+  @doc """
+  Since the format of env_logger is different from that of elixir, it is recommended to use Mediasoup.LoggerProxy instead.
+  Initialize the logger with env logger. Same as the env_logger::init() call.
+  For more information on the env logger, please refer to the Rust crate documentation.
+  https://docs.rs/env_logger/latest/env_logger/
+  """
+  def init_env_logger(), do: Mediasoup.Nif.init_env_logger()
 end

--- a/lib/nif.ex
+++ b/lib/nif.ex
@@ -473,6 +473,14 @@ defmodule Mediasoup.Nif do
   @spec data_producer_event(reference, pid, [atom()]) :: {:ok} | {:error}
   def data_producer_event(_producer, _pid, _event_types), do: :erlang.nif_error(:nif_not_loaded)
 
+  # logger proxy
+  def set_logger_proxy_process(_pid, _max_level), do: :erlang.nif_error(:nif_not_loaded)
+
+  # for test
+  def debug_logger(_level, _msg), do: :erlang.nif_error(:nif_not_loaded)
+
+  def init_env_logger(), do: :erlang.nif_error(:nif_not_loaded)
+
   defp handle_async_nif_result(result) do
     case result do
       {:ok, result_key} ->

--- a/native/mediasoup_elixir/Cargo.lock
+++ b/native/mediasoup_elixir/Cargo.lock
@@ -817,6 +817,7 @@ dependencies = [
  "async-executor",
  "env_logger",
  "futures-lite 2.3.0",
+ "log",
  "mediasoup",
  "num_cpus",
  "once_cell",

--- a/native/mediasoup_elixir/Cargo.toml
+++ b/native/mediasoup_elixir/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version = "1.0.197", features = ["derive"] }
 serde-transcode = "1.1"
 serde_json = "1.0"
 env_logger = "0.11.3"
+log = { version = "0.4.21", features = ["std"] }
 
 [features]
 default = ["nif_version_2_15"]

--- a/native/mediasoup_elixir/src/lib.rs
+++ b/native/mediasoup_elixir/src/lib.rs
@@ -4,6 +4,7 @@ mod data_consumer;
 mod data_producer;
 mod data_structure;
 mod json_serde;
+mod logger;
 mod macros;
 mod pipe_transport;
 mod plain_transport;
@@ -76,6 +77,7 @@ use data_producer::{
     data_producer_close, data_producer_closed, data_producer_event, data_producer_id,
     data_producer_sctp_stream_parameters, data_producer_type,
 };
+use logger::{debug_logger, init_env_logger, set_logger_proxy_process};
 
 use futures_lite::future;
 use mediasoup::consumer::Consumer;
@@ -279,14 +281,17 @@ rustler::init! {
         data_producer_closed,
         data_producer_event,
 
+        // logger proxy,
+
+        init_env_logger,
+        set_logger_proxy_process,
+        debug_logger,
 
     ],
     load = on_load
 }
 
 fn on_load<'a>(env: Env<'a>, _load_info: Term<'a>) -> bool {
-    env_logger::init();
-
     // This macro will take care of defining and initializing a new resource
     // object type.
     rustler::resource!(WorkerRef, env);

--- a/native/mediasoup_elixir/src/logger.rs
+++ b/native/mediasoup_elixir/src/logger.rs
@@ -1,0 +1,148 @@
+use crate::atoms;
+use crate::send_msg_from_other_thread;
+use log::{Level, Metadata, Record};
+use rustler::{NifStruct, NifUnitEnum};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
+
+struct LoggerProxy {
+    pid: Mutex<Option<rustler::LocalPid>>,
+    max_level: AtomicUsize,
+}
+
+impl LoggerProxy {
+    fn logger_proxy_process(&self) -> Option<rustler::LocalPid> {
+        let guard = self.pid.lock().unwrap();
+        guard.clone()
+    }
+    fn set_proxy_process(&self, pid: rustler::LocalPid) {
+        if let Ok(ref mut mutex) = self.pid.lock() {
+            **mutex = Some(pid);
+        }
+    }
+    fn set_max_level(&self, filter: log::LevelFilter) {
+        log::set_max_level(filter);
+        self.max_level.store(filter as usize, Ordering::Relaxed);
+    }
+}
+
+fn ignore_log(record: &Record) -> bool {
+    // Ignore this as it is an error log with no way to deal with it.
+    record
+        .args()
+        .to_string()
+        .ends_with("Channel already closed")
+}
+
+impl log::Log for LoggerProxy {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        (metadata.level() as usize) < self.max_level.load(Ordering::Relaxed)
+    }
+
+    fn log(&self, record: &Record) {
+        if ignore_log(record) {
+            return;
+        }
+        if let Option::Some(pid) = self.logger_proxy_process() {
+            let rec = LoggerProxyRecord {
+                level: record.level().into(),
+                target: record.target().to_string(),
+                body: record.args().to_string(),
+                module_path: record.module_path().map(str::to_string),
+                file: record.file().map(str::to_string),
+                line: record.line(),
+            };
+            send_msg_from_other_thread(pid, rec);
+        }
+    }
+    fn flush(&self) {}
+}
+
+#[rustler::nif]
+pub fn init_env_logger() {
+    env_logger::init();
+}
+
+static LOGGER_PROXY: LoggerProxy = LoggerProxy {
+    pid: Mutex::new(None),
+    max_level: AtomicUsize::new(log::LevelFilter::Info as usize),
+};
+
+#[rustler::nif]
+pub fn set_logger_proxy_process(
+    pid: rustler::LocalPid,
+    filter: NifLevelFilter,
+) -> rustler::NifResult<rustler::Atom> {
+    let _ = log::set_logger(&LOGGER_PROXY);
+
+    LOGGER_PROXY.set_proxy_process(pid);
+    LOGGER_PROXY.set_max_level(filter.into());
+
+    Ok(atoms::ok())
+}
+
+#[rustler::nif]
+pub fn debug_logger(level: NifLevel, message: String) -> rustler::NifResult<rustler::Atom> {
+    match level {
+        NifLevel::Error => log::log!(log::Level::Error, "{}", message),
+        NifLevel::Warn => log::log!(log::Level::Warn, "{}", message),
+        NifLevel::Info => log::log!(log::Level::Info, "{}", message),
+        NifLevel::Debug => log::log!(log::Level::Debug, "{}", message),
+    }
+
+    Ok(atoms::ok())
+}
+
+#[derive(NifStruct)]
+#[module = "Mediasoup.LoggerProxy.Record"]
+pub struct LoggerProxyRecord {
+    level: NifLevel,
+    target: String,
+    body: String,
+    module_path: Option<String>,
+    file: Option<String>,
+    line: Option<u32>,
+}
+
+#[derive(NifUnitEnum)]
+enum NifLevel {
+    Error,
+    Warn,
+    Info,
+    Debug,
+}
+
+#[derive(NifUnitEnum)]
+enum NifLevelFilter {
+    Off,
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+impl From<Level> for NifLevel {
+    fn from(level: Level) -> NifLevel {
+        match level {
+            Level::Error => NifLevel::Error,
+            Level::Warn => NifLevel::Warn,
+            Level::Info => NifLevel::Info,
+            Level::Debug => NifLevel::Debug,
+            Level::Trace => NifLevel::Debug,
+        }
+    }
+}
+
+impl From<NifLevelFilter> for log::LevelFilter {
+    fn from(level: NifLevelFilter) -> log::LevelFilter {
+        match level {
+            NifLevelFilter::Off => log::LevelFilter::Off,
+            NifLevelFilter::Error => log::LevelFilter::Error,
+            NifLevelFilter::Warn => log::LevelFilter::Warn,
+            NifLevelFilter::Info => log::LevelFilter::Info,
+            NifLevelFilter::Debug => log::LevelFilter::Debug,
+            NifLevelFilter::Trace => log::LevelFilter::Trace,
+        }
+    }
+}

--- a/test/consumer_test.exs
+++ b/test/consumer_test.exs
@@ -2,6 +2,11 @@ defmodule ConsumerTest do
   use ExUnit.Case
 
   setup do
+    children = [
+      {Mediasoup.LoggerProxy, max_level: :info}
+    ]
+
+    Supervisor.start_link(children, strategy: :one_for_one, name: ConsumerTest.Supervisor)
     {:ok, worker} = Mediasoup.Worker.start_link()
 
     %{worker: worker}

--- a/test/data_consumer_test.exs
+++ b/test/data_consumer_test.exs
@@ -2,6 +2,7 @@ defmodule DataConsumerTest do
   use ExUnit.Case
 
   setup do
+    Mediasoup.LoggerProxy.start_link(max_level: :info)
     {:ok, worker} = Mediasoup.Worker.start_link()
 
     %{worker: worker}

--- a/test/data_producer_test.exs
+++ b/test/data_producer_test.exs
@@ -2,6 +2,7 @@ defmodule DataProducerTest do
   use ExUnit.Case
 
   setup do
+    Mediasoup.LoggerProxy.start_link(max_level: :info)
     {:ok, worker} = Mediasoup.Worker.start_link()
 
     %{worker: worker}

--- a/test/integration/test_smoke.ex
+++ b/test/integration/test_smoke.ex
@@ -3,6 +3,7 @@ defmodule IntegrateTest.SmokeTest do
   Smoke test with dializer check
   """
   def smoke() do
+    Mediasoup.LoggerProxy.start_link(max_level: :info)
     {:ok, worker} = Mediasoup.Worker.start_link()
 
     {:ok, router} =

--- a/test/logger_proxy_test.exs
+++ b/test/logger_proxy_test.exs
@@ -5,7 +5,7 @@ defmodule Mediasoup.LoggerProxyTest do
   alias Mediasoup.LoggerProxy
 
   test "max_level off " do
-    Mediasoup.LoggerProxy.start_link(max_level: :off)
+    LoggerProxy.start_link(max_level: :off)
 
     refute capture_log(fn ->
              Mediasoup.Nif.debug_logger(:error, "test")
@@ -24,7 +24,7 @@ defmodule Mediasoup.LoggerProxyTest do
   end
 
   test "max_level error " do
-    Mediasoup.LoggerProxy.start_link(max_level: :error)
+    LoggerProxy.start_link(max_level: :error)
 
     assert capture_log(fn ->
              Mediasoup.Nif.debug_logger(:error, "test")
@@ -43,7 +43,7 @@ defmodule Mediasoup.LoggerProxyTest do
   end
 
   test " max_level warn" do
-    Mediasoup.LoggerProxy.start_link(max_level: :warn)
+    LoggerProxy.start_link(max_level: :warn)
 
     assert capture_log(fn ->
              Mediasoup.Nif.debug_logger(:warn, "test")
@@ -57,7 +57,7 @@ defmodule Mediasoup.LoggerProxyTest do
   end
 
   test " max_level info" do
-    Mediasoup.LoggerProxy.start_link(max_level: :info)
+    LoggerProxy.start_link(max_level: :info)
 
     assert capture_log(fn ->
              Mediasoup.Nif.debug_logger(:info, "test")
@@ -71,7 +71,7 @@ defmodule Mediasoup.LoggerProxyTest do
   end
 
   test " max_level debug" do
-    Mediasoup.LoggerProxy.start_link(max_level: :debug)
+    LoggerProxy.start_link(max_level: :debug)
 
     assert capture_log(fn ->
              Mediasoup.Nif.debug_logger(:info, "test")

--- a/test/logger_proxy_test.exs
+++ b/test/logger_proxy_test.exs
@@ -1,0 +1,86 @@
+defmodule Mediasoup.LoggerProxyTest do
+  use ExUnit.Case
+  import ExUnit.CaptureLog
+
+  alias Mediasoup.LoggerProxy
+
+  test "max_level off " do
+    Mediasoup.LoggerProxy.start_link(max_level: :off)
+
+    refute capture_log(fn ->
+             Mediasoup.Nif.debug_logger(:error, "test")
+             Process.sleep(10)
+           end) =~ "test"
+
+    refute capture_log(fn ->
+             Mediasoup.Nif.debug_logger(:warn, "test")
+             Process.sleep(10)
+           end) =~ "test"
+
+    refute capture_log(fn ->
+             Mediasoup.Nif.debug_logger(:info, "test")
+             Process.sleep(10)
+           end) =~ "test"
+  end
+
+  test "max_level error " do
+    Mediasoup.LoggerProxy.start_link(max_level: :error)
+
+    assert capture_log(fn ->
+             Mediasoup.Nif.debug_logger(:error, "test")
+             Process.sleep(10)
+           end) =~ "test"
+
+    refute capture_log(fn ->
+             Mediasoup.Nif.debug_logger(:warn, "test")
+             Process.sleep(10)
+           end) =~ "test"
+
+    refute capture_log(fn ->
+             Mediasoup.Nif.debug_logger(:warn, "test")
+             Process.sleep(10)
+           end) =~ "test"
+  end
+
+  test " max_level warn" do
+    Mediasoup.LoggerProxy.start_link(max_level: :warn)
+
+    assert capture_log(fn ->
+             Mediasoup.Nif.debug_logger(:warn, "test")
+             Process.sleep(10)
+           end) =~ "test"
+
+    refute capture_log(fn ->
+             Mediasoup.Nif.debug_logger(:info, "test")
+             Process.sleep(10)
+           end) =~ "test"
+  end
+
+  test " max_level info" do
+    Mediasoup.LoggerProxy.start_link(max_level: :info)
+
+    assert capture_log(fn ->
+             Mediasoup.Nif.debug_logger(:info, "test")
+             Process.sleep(10)
+           end) =~ "test"
+
+    refute capture_log(fn ->
+             Mediasoup.Nif.debug_logger(:debug, "test")
+             Process.sleep(10)
+           end) =~ "test"
+  end
+
+  test " max_level debug" do
+    Mediasoup.LoggerProxy.start_link(max_level: :debug)
+
+    assert capture_log(fn ->
+             Mediasoup.Nif.debug_logger(:info, "test")
+             Process.sleep(10)
+           end) =~ "test"
+
+    assert capture_log(fn ->
+             Mediasoup.Nif.debug_logger(:debug, "test")
+             Process.sleep(10)
+           end) =~ "test"
+  end
+end

--- a/test/pipe_transport_test.exs
+++ b/test/pipe_transport_test.exs
@@ -1,5 +1,6 @@
 defmodule PipeTransportTest do
   use ExUnit.Case
+  import ExUnit.CaptureLog
 
   setup do
     Mediasoup.LoggerProxy.start_link(max_level: :info)

--- a/test/pipe_transport_test.exs
+++ b/test/pipe_transport_test.exs
@@ -2,6 +2,7 @@ defmodule PipeTransportTest do
   use ExUnit.Case
 
   setup do
+    Mediasoup.LoggerProxy.start_link(max_level: :info)
     {:ok, worker} = Mediasoup.Worker.start_link()
 
     %{worker: worker}

--- a/test/plain_transport_test.exs
+++ b/test/plain_transport_test.exs
@@ -6,6 +6,7 @@ defmodule MediasoupElixirPlainTransportTest do
   setup :verify_worker_leak_on_exit!
 
   setup do
+    Mediasoup.LoggerProxy.start_link(max_level: :info)
     {:ok, worker} = Mediasoup.Worker.start_link()
     %{worker: worker}
   end

--- a/test/producer_test.exs
+++ b/test/producer_test.exs
@@ -2,6 +2,7 @@ defmodule ProducerTest do
   use ExUnit.Case
 
   setup do
+    Mediasoup.LoggerProxy.start_link(max_level: :info)
     {:ok, worker} = Mediasoup.Worker.start_link()
 
     %{worker: worker}

--- a/test/webrtc_server_test.exs
+++ b/test/webrtc_server_test.exs
@@ -6,6 +6,7 @@ defmodule MediasoupElixirWebRtcServerTest do
   setup :verify_worker_leak_on_exit!
 
   setup do
+    Mediasoup.LoggerProxy.start_link(max_level: :info)
     {:ok, worker} = Mediasoup.Worker.start_link()
     %{worker: worker}
   end

--- a/test/webrtc_server_test.exs
+++ b/test/webrtc_server_test.exs
@@ -1,5 +1,6 @@
 defmodule MediasoupElixirWebRtcServerTest do
   use ExUnit.Case
+  import ExUnit.CaptureLog
 
   import Mediasoup.TestUtil
   setup_all :worker_leak_setup_all
@@ -20,6 +21,8 @@ defmodule MediasoupElixirWebRtcServerTest do
   end
 
   test "unavailable_infos_fails", %{worker: worker} do
-    IntegrateTest.WebRtcServerTest.unavailable_infos_fails(worker)
+    assert capture_log(fn ->
+             IntegrateTest.WebRtcServerTest.unavailable_infos_fails(worker)
+           end) =~ "address already in use"
   end
 end

--- a/test/webrtc_transport_test.exs
+++ b/test/webrtc_transport_test.exs
@@ -6,6 +6,7 @@ defmodule MediasoupElixirWebRtcTransportTest do
   setup :verify_worker_leak_on_exit!
 
   setup do
+    Mediasoup.LoggerProxy.start_link(max_level: :info)
     {:ok, worker} = Mediasoup.Worker.start_link()
     %{worker: worker}
   end

--- a/test/worker_test.exs
+++ b/test/worker_test.exs
@@ -4,6 +4,11 @@ defmodule WorkerTest do
   setup_all :worker_leak_setup_all
   setup :verify_worker_leak_on_exit!
 
+  setup do
+    Mediasoup.LoggerProxy.start_link(max_level: :info)
+    :ok
+  end
+
   test "create_worker_with_default_settings" do
     IntegrateTest.WorkerTest.create_worker_with_default_settings()
   end


### PR DESCRIPTION
By default, logs are no longer output.
If you prefer the same env_logger behavior as before, call `Mediasoup.init_env_logger()` once first. If you want to output with Elixir's Logger, add Mediasoup.LoggerProxy to the supervisor tree of your application.