### PR TITLE
Remove resouce method for DisposableResourceWrapper

### DIFF
--- a/native/mediasoup_elixir/Cargo.lock
+++ b/native/mediasoup_elixir/Cargo.lock
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "mediasoup_elixir"
-version = "3.14.1"
+version = "3.14.2"
 dependencies = [
  "async-executor",
  "env_logger",

--- a/native/mediasoup_elixir/src/pipe_transport.rs
+++ b/native/mediasoup_elixir/src/pipe_transport.rs
@@ -110,7 +110,8 @@ pub fn pipe_transport_consume(
         transport
             .consume(option)
             .await
-            .map(ConsumerRef::resource)
+            .map(ConsumerRef::new)
+            .map(ResourceArc::new)
             .map_err(|error| format!("{}", error))
     })
 }
@@ -128,7 +129,8 @@ pub fn pipe_transport_consume_data(
         transport
             .consume_data(option)
             .await
-            .map(DataConsumerRef::resource)
+            .map(DataConsumerRef::new)
+            .map(ResourceArc::new)
             .map_err(|error| format!("{}", error))
     })
 }
@@ -164,7 +166,8 @@ pub fn pipe_transport_produce(
         transport
             .produce(option)
             .await
-            .map(ProducerRef::resource)
+            .map(ProducerRef::new)
+            .map(ResourceArc::new)
             .map_err(|error| format!("{}", error))
     })
 }
@@ -182,7 +185,8 @@ pub fn pipe_transport_produce_data(
         transport
             .produce_data(option)
             .await
-            .map(DataProducerRef::resource)
+            .map(DataProducerRef::new)
+            .map(ResourceArc::new)
             .map_err(|error| format!("{}", error))
     })
 }

--- a/native/mediasoup_elixir/src/plain_transport.rs
+++ b/native/mediasoup_elixir/src/plain_transport.rs
@@ -145,7 +145,8 @@ pub fn plain_transport_produce(
         transport
             .produce(option)
             .await
-            .map(ProducerRef::resource)
+            .map(ProducerRef::new)
+            .map(ResourceArc::new)
             .map_err(|error| format!("{}", error))
     })
 }
@@ -164,7 +165,8 @@ pub fn plain_transport_consume(
         transport
             .consume(option)
             .await
-            .map(ConsumerRef::resource)
+            .map(ConsumerRef::new)
+            .map(ResourceArc::new)
             .map_err(|error| format!("{}", error))
     })
 }

--- a/native/mediasoup_elixir/src/resource.rs
+++ b/native/mediasoup_elixir/src/resource.rs
@@ -1,30 +1,5 @@
 use crate::atoms;
-use rustler::ResourceArc;
 use std::sync::Mutex;
-/*
-pub struct ResourceWrapper<T>(T);
-impl<T> ResourceWrapper<T> {
-    pub fn new(value: T) -> Self {
-        Self(value)
-    }
-}
-
-impl<T> ResourceWrapper<T>
-where
-    ResourceWrapper<T>: rustler::resource::ResourceTypeProvider,
-{
-    pub fn resource(value: T) -> ResourceArc<Self> {
-        ResourceArc::new(Self::new(value))
-    }
-}
-
-impl<T> std::ops::Deref for ResourceWrapper<T> {
-    type Target = T;
-    fn deref(&self) -> &T {
-        &self.0
-    }
-}*/
-
 pub struct DisposableResourceWrapper<T>(pub Mutex<Option<T>>);
 impl<T> DisposableResourceWrapper<T> {
     pub fn new(value: T) -> Self {
@@ -56,14 +31,5 @@ where
             .map_err(|_error| rustler::Error::Term(Box::new(atoms::poison_error())))?
             .ok_or_else(|| rustler::Error::Term(Box::new(atoms::terminated())))?;
         Ok(resource)
-    }
-}
-
-impl<T> DisposableResourceWrapper<T>
-where
-    DisposableResourceWrapper<T>: rustler::resource::ResourceTypeProvider,
-{
-    pub fn resource(value: T) -> ResourceArc<Self> {
-        ResourceArc::new(Self::new(value))
     }
 }

--- a/native/mediasoup_elixir/src/router.rs
+++ b/native/mediasoup_elixir/src/router.rs
@@ -40,7 +40,8 @@ pub fn router_create_webrtc_transport(
         router
             .create_webrtc_transport(option)
             .await
-            .map(WebRtcTransportRef::resource)
+            .map(WebRtcTransportRef::new)
+            .map(ResourceArc::new)
             .map_err(|error| format!("{}", error))
     })
 }
@@ -60,7 +61,8 @@ pub fn router_create_plain_transport(
         router
             .create_plain_transport(option)
             .await
-            .map(PlainTransportRef::resource)
+            .map(PlainTransportRef::new)
+            .map(ResourceArc::new)
             .map_err(|error| format!("{}", error))
     })
 }
@@ -87,7 +89,8 @@ pub fn router_create_pipe_transport(
         router
             .create_pipe_transport(option)
             .await
-            .map(PipeTransportRef::resource)
+            .map(PipeTransportRef::new)
+            .map(ResourceArc::new)
             .map_err(|error| format!("{}", error))
     })
 }

--- a/native/mediasoup_elixir/src/webrtc_transport.rs
+++ b/native/mediasoup_elixir/src/webrtc_transport.rs
@@ -59,7 +59,8 @@ pub fn webrtc_transport_consume(
         transport
             .consume(option)
             .await
-            .map(ConsumerRef::resource)
+            .map(ConsumerRef::new)
+            .map(ResourceArc::new)
             .map_err(|error| format!("{}", error))
     })
 }
@@ -78,7 +79,8 @@ pub fn webrtc_transport_consume_data(
         transport
             .consume_data(option)
             .await
-            .map(DataConsumerRef::resource)
+            .map(DataConsumerRef::new)
+            .map(ResourceArc::new)
             .map_err(|error| format!("{}", error))
     })
 }
@@ -113,7 +115,8 @@ pub fn webrtc_transport_produce(
         transport
             .produce(option)
             .await
-            .map(ProducerRef::resource)
+            .map(ProducerRef::new)
+            .map(ResourceArc::new)
             .map_err(|error| format!("{}", error))
     })
 }
@@ -131,7 +134,8 @@ pub fn webrtc_transport_produce_data(
         transport
             .produce_data(option)
             .await
-            .map(DataProducerRef::resource)
+            .map(DataProducerRef::new)
+            .map(ResourceArc::new)
             .map_err(|error| format!("{}", error))
     })
 }

--- a/native/mediasoup_elixir/src/worker.rs
+++ b/native/mediasoup_elixir/src/worker.rs
@@ -45,7 +45,8 @@ pub fn worker_create_router(
         worker
             .create_router(option)
             .await
-            .map(RouterRef::resource)
+            .map(RouterRef::new)
+            .map(ResourceArc::new)
             .map_err(|error| format!("{}", error))
     })
 }
@@ -64,7 +65,8 @@ pub fn worker_create_webrtc_server(
         worker
             .create_webrtc_server(option)
             .await
-            .map(WebRtcServerRef::resource)
+            .map(WebRtcServerRef::new)
+            .map(ResourceArc::new)
             .map_err(|error| format!("{}", error))
     })
 }
@@ -160,7 +162,7 @@ fn create_worker_impl(
                         GLOBAL_WORKER_COUNT.fetch_sub(1, Ordering::Relaxed);
                     })
                     .detach();
-                WorkerRef::resource(worker)
+                ResourceArc::new(WorkerRef::new(worker))
             })
             .map_err(|error| format!("{}", error))
     })


### PR DESCRIPTION
Because can not build with rustler 0.34.0 (rustler::resource::ResourceTypeProvider to private)