### PR TITLE
update ci image to macOS 13

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
               use-cross: true,
               cross-version: "from-source",
             }
-          - { target: x86_64-apple-darwin, os: macos-12 }
+          - { target: x86_64-apple-darwin, os: macos-13 }
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04 }
           - {
               target: x86_64-unknown-linux-musl,


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/10721

## Summary by Sourcery

CI:
- Update the CI workflow to use macOS 13 for the x86_64-apple-darwin target.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the macOS version in the GitHub Actions workflow for building precompiled NIFs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->