### PR TITLE
SRE-2367: use latest action runner controller

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
 
   publish:
-    runs-on: ubuntu-latest
+    runs-on: utility-amd64
     needs: build_release
     if: startsWith(github.ref, 'refs/tags/')
     steps:

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -5,7 +5,7 @@ jobs:
   reviewdog:
     timeout-minutes: 40
     name: reviewdog
-    runs-on: ubuntu-latest
+    runs-on: utility-staging-amd64
     strategy:
       matrix:
         rust:

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   lint-rust:
     name: Lint Rust
-    runs-on: ubuntu-latest
+    runs-on: utility-staging-amd64
     strategy:
       matrix:
         manifest:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
   test:
     timeout-minutes: 40
     name: Build and test
-    runs-on: ubuntu-latest
+    runs-on: utility-staging-amd64
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Linear Ticket

[SRE-2367](https://linear.app/ovice/issue/SRE-2367/migrate-github-actions-to-actions-runner-controller-production)

## Overview
 use Latest Action Runner Controller

## Areas to focus on
- utility-staging-amd64 for staging 
- utility-amd64 for production 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Infrastructure**
	- Updated GitHub Actions workflow runners from `ubuntu-latest` to custom environments:
		- `utility-amd64` for release workflow
		- `utility-staging-amd64` for reviewdog, Rust CI, and test workflows
	- Temporarily disabled Clippy linting in Rust CI workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->