### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,34 +18,34 @@ jobs:
         job:
           - {
               target: arm-unknown-linux-gnueabihf,
-              os: ubuntu-20.04,
+              os: ubuntu-22.04,
               use-cross: true,
               cross-version: "from-source",
             }
           - {
               target: aarch64-unknown-linux-gnu,
-              os: ubuntu-20.04,
+              os: ubuntu-22.04,
               use-cross: true,
               cross-version: "from-source",
             }
           - {
               target: aarch64-unknown-linux-musl,
-              os: ubuntu-20.04,
+              os: ubuntu-22.04,
               use-cross: true,
               cross-version: "from-source",
             }
           - { target: aarch64-apple-darwin, os: macos-14 }
           - {
               target: riscv64gc-unknown-linux-gnu,
-              os: ubuntu-20.04,
+              os: ubuntu-22.04,
               use-cross: true,
               cross-version: "from-source",
             }
           - { target: x86_64-apple-darwin, os: macos-13 }
-          - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04 }
+          - { target: x86_64-unknown-linux-gnu, os: ubuntu-22.04 }
           - {
               target: x86_64-unknown-linux-musl,
-              os: ubuntu-20.04,
+              os: ubuntu-22.04,
               use-cross: true,
               cross-version: "from-source",
             }


### PR DESCRIPTION
 
--
This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101

<br class="Apple-interchange-newline">

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated build environment for Linux-based targets to use Ubuntu 22.04.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->