### PR TITLE
fix 'warning: the log level :warn is deprecated, use :warning instead'

### DIFF
--- a/lib/logger_proxy.ex
+++ b/lib/logger_proxy.ex
@@ -76,7 +76,7 @@ defmodule Mediasoup.LoggerProxy do
                _ -> {:cont, acc}
              end
            end) do
-      Logger.log(msg.level, msg.body, %{
+      Logger.log(to_logger_level(msg.level), msg.body, %{
         line: msg.line,
         file: msg.file,
         mfa: msg.target,
@@ -86,6 +86,12 @@ defmodule Mediasoup.LoggerProxy do
 
     {:noreply, state}
   end
+
+  defp to_logger_level(:error), do: :error
+  defp to_logger_level(:warn), do: :warning
+  defp to_logger_level(:info), do: :info
+  defp to_logger_level(:debug), do: :debug
+  defp to_logger_level(_), do: :error
 
   def child_spec(opts) do
     %{

--- a/test/logger_proxy_test.exs
+++ b/test/logger_proxy_test.exs
@@ -134,7 +134,7 @@ defmodule Mediasoup.LoggerProxyTest do
           mediaCodecs: []
         })
 
-      assert capture_log([level: :warn], fn ->
+      assert capture_log([level: :warning], fn ->
                Router.can_consume?(router, "d117b485-7490-4146-812f-d3f744f0a8c7", %{
                  codecs: [],
                  headerExtensions: [],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency in log level handling to ensure custom log levels are correctly mapped to standard log levels.
- **Tests**
  - Updated tests to align with the new log level mapping, ensuring accurate log capture and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->