### PR TITLE
Stop Elixir process when Mediasoup worker thread stops

### DIFF
--- a/native/mediasoup_elixir/Cargo.lock
+++ b/native/mediasoup_elixir/Cargo.lock
@@ -781,9 +781,8 @@ checksum = "b6e8aaa3f231bb4bd57b84b2d5dc3ae7f350265df8aa96492e0bc394a1571909"
 
 [[package]]
 name = "mediasoup"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0640723cc3a9e468faa0be9054cfe8c77c7f496fc6fbb10364d19c648aebc42"
+version = "0.18.1"
+source = "git+https://github.com/oviceinc/mediasoup?rev=20196923f3b8d019d0313ca69ac8b473d0e48fd7#20196923f3b8d019d0313ca69ac8b473d0e48fd7"
 dependencies = [
  "async-channel",
  "async-executor",
@@ -813,9 +812,8 @@ dependencies = [
 
 [[package]]
 name = "mediasoup-sys"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158236449ba9429acd80459fd6f8a71e2d097d898f6b297c2f6b0a6e8b4b70ee"
+version = "0.9.2"
+source = "git+https://github.com/oviceinc/mediasoup?rev=20196923f3b8d019d0313ca69ac8b473d0e48fd7#20196923f3b8d019d0313ca69ac8b473d0e48fd7"
 dependencies = [
  "planus",
  "planus-codegen",

--- a/native/mediasoup_elixir/Cargo.toml
+++ b/native/mediasoup_elixir/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 rustler = { version = "0.36.0", default-features = false, features = ["serde"] }
-mediasoup = "0.17.0"
+mediasoup =  { git = "https://github.com/oviceinc/mediasoup", rev = "20196923f3b8d019d0313ca69ac8b473d0e48fd7" }
 futures-lite = "2.3.0"
 once_cell = "1.19.0"
 num_cpus = "1.16.0"

--- a/test/worker_test.exs
+++ b/test/worker_test.exs
@@ -9,6 +9,15 @@ defmodule WorkerTest do
     :ok
   end
 
+  test "worker_closed_test" do
+    {:ok, worker} = Mediasoup.Worker.start_link()
+    Mediasoup.Worker.event(worker, self(), [:on_close, :on_dead])
+    GenServer.call(worker, :debug_stop_worker)
+    ref = Process.monitor(worker)
+    assert_receive {:DOWN, ^ref, :process, ^worker, :normal}
+    assert Mediasoup.Worker.closed?(worker) === true
+  end
+
   test "create_worker_with_default_settings" do
     IntegrateTest.WorkerTest.create_worker_with_default_settings()
   end


### PR DESCRIPTION
Temporarily replace with std::abort to avoid full shutdown; will revert when fix is released upstream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved worker process handling to automatically respond to close and dead events.
	- Added the ability to stop a worker process through a new debug command.
- **Bug Fixes**
	- Ensured proper cleanup and closure of worker processes upon termination.
- **Tests**
	- Introduced a new test to verify correct worker shutdown and closure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->