### PR TITLE
Always force_build when testing locally

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,6 @@ jobs:
       matrix:
         rust:
           - stable
-    env:
-      MIX_ENV: test
-      RUSTLER_PRECOMPILATION_MEDIASOUP_BUILD: "true"
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Set up Elixir
@@ -74,8 +71,6 @@ jobs:
       matrix:
         rust:
           - stable
-    env:
-      RUSTLER_PRECOMPILATION_MEDIASOUP_BUILD: "true"
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Set up Elixir

--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@
 [Mediasoup](https://mediasoup.org/) port for Elixir
 
 ## Installation
-### Requirement
+### Requirement for development
   * [Rust](https://www.rust-lang.org/)
   * `make`, `python3-pip` and `c/c++ compilers` for build for mediasoup

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,4 @@
+import Config
+
+# always build when testing
+config :rustler_precompiled, :force_build, mediasoup_elixir: true

--- a/lib/nif.ex
+++ b/lib/nif.ex
@@ -30,19 +30,31 @@ defmodule Mediasoup.Nif do
       end
     end
 
-    def force_build?(),
-      do:
-        System.get_env("RUSTLER_PRECOMPILATION_MEDIASOUP_BUILD") in ["1", "true"] or
-          not prebuild_target?()
+    def force_build do
+      cond do
+        not prebuild_target?() ->
+          [force_build: true]
+
+        System.get_env("RUSTLER_PRECOMPILATION_MEDIASOUP_BUILD") in ["1", "true"] ->
+          [force_build: true]
+
+        System.get_env("RUSTLER_PRECOMPILATION_MEDIASOUP_BUILD") != nil ->
+          [force_build: false]
+
+        true ->
+          []
+      end
+    end
   end
 
   use RustlerPrecompiled,
-    otp_app: :mediasoup_elixir,
-    crate: "mediasoup_elixir",
-    base_url: "https://github.com/oviceinc/mediasoup-elixir/releases/download/v#{version}",
-    force_build: Build.force_build?(),
-    targets: Build.prebuild_targets(),
-    version: version
+      [
+        otp_app: :mediasoup_elixir,
+        crate: "mediasoup_elixir",
+        base_url: "https://github.com/oviceinc/mediasoup-elixir/releases/download/v#{version}",
+        targets: Build.prebuild_targets(),
+        version: version
+      ] ++ Build.force_build()
 
   #  use Rustler, otp_app: :mediasoup_elixir, crate: :mediasoup_elixir
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified the installation requirements in the README to specify they are for development.
- **Chores**
  - Updated test and lint workflows by removing certain environment variables from their configurations.
- **Refactor**
  - Changed how build options are handled for the Rustler precompiled artifact, modifying the force build behavior.
- **New Features**
  - Added configuration to always force-build the mediasoup_elixir Rustler precompiled artifact during tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->