### PR TITLE
wrap the GenServer.call to prevent it from crashing and return {:error, :terminated} instead

### DIFF
--- a/lib/data_consumer.ex
+++ b/lib/data_consumer.ex
@@ -67,7 +67,11 @@ defmodule Mediasoup.DataConsumer do
 
   @spec closed?(t) :: boolean
   def closed?(%DataConsumer{pid: pid}) do
-    !Process.alive?(pid) || NifWrap.call(pid, {:closed?, []})
+    !Process.alive?(pid) ||
+      case NifWrap.call(pid, {:closed?, []}) do
+        {:error, :terminated} -> true
+        result -> result
+      end
   end
 
   @type event_type :: :on_close

--- a/lib/data_producer.ex
+++ b/lib/data_producer.ex
@@ -48,7 +48,11 @@ defmodule Mediasoup.DataProducer do
 
   @spec closed?(t) :: boolean
   def closed?(%DataProducer{pid: pid}) do
-    !Process.alive?(pid) || NifWrap.call(pid, {:closed?, []})
+    !Process.alive?(pid) ||
+      case NifWrap.call(pid, {:closed?, []}) do
+        {:error, :terminated} -> true
+        result -> result
+      end
   end
 
   @type event_type :: :on_close

--- a/lib/pipe_transport.ex
+++ b/lib/pipe_transport.ex
@@ -102,7 +102,11 @@ defmodule Mediasoup.PipeTransport do
   Tells whether the given PipeTransport is closed on the local node.
   """
   def closed?(%PipeTransport{pid: pid}) do
-    !Process.alive?(pid) || NifWrap.call(pid, {:closed?, []})
+    !Process.alive?(pid) ||
+      case NifWrap.call(pid, {:closed?, []}) do
+        {:error, :terminated} -> true
+        result -> result
+      end
   end
 
   @spec consume(t, Consumer.Options.t() | map()) ::

--- a/lib/plain_transport.ex
+++ b/lib/plain_transport.ex
@@ -187,7 +187,11 @@ defmodule Mediasoup.PlainTransport do
   Tells whether the given PlainTransport is closed on the local node.
   """
   def closed?(%PlainTransport{pid: pid}) do
-    !Process.alive?(pid) || NifWrap.call(pid, {:closed?, []})
+    !Process.alive?(pid) ||
+      case NifWrap.call(pid, {:closed?, []}) do
+        {:error, :terminated} -> true
+        result -> result
+      end
   end
 
   @spec produce(t, Producer.Options.t() | map()) ::

--- a/lib/producer.ex
+++ b/lib/producer.ex
@@ -123,7 +123,11 @@ defmodule Mediasoup.Producer do
   Tells whether the given producer is closed on the local node.
   """
   def closed?(%Producer{pid: pid}) do
-    !Process.alive?(pid) || NifWrap.call(pid, {:closed?, []})
+    !Process.alive?(pid) ||
+      case NifWrap.call(pid, {:closed?, []}) do
+        {:error, :terminated} -> true
+        result -> result
+      end
   end
 
   @spec paused?(t) :: boolean() | {:error}

--- a/lib/router.ex
+++ b/lib/router.ex
@@ -114,7 +114,11 @@ defmodule Mediasoup.Router do
   Tells whether the given router is closed on the local node.
   """
   def closed?(%Router{pid: pid}) do
-    !Process.alive?(pid) || NifWrap.call(pid, {:closed?, []})
+    !Process.alive?(pid) ||
+      case NifWrap.call(pid, {:closed?, []}) do
+        {:error, :terminated} -> true
+        result -> result
+      end
   end
 
   @spec create_webrtc_transport(t, WebRtcTransport.create_option()) ::

--- a/lib/webrtc_server.ex
+++ b/lib/webrtc_server.ex
@@ -80,7 +80,11 @@ defmodule Mediasoup.WebRtcServer do
   Tells whether the given WebRtcServer is closed on the local node.
   """
   def closed?(%WebRtcServer{pid: pid}) do
-    !Process.alive?(pid) || NifWrap.call(pid, {:closed?, []})
+    !Process.alive?(pid) ||
+      case NifWrap.call(pid, {:closed?, []}) do
+        {:error, :terminated} -> true
+        result -> result
+      end
   end
 
   @spec dump(t) :: any | {:error, :terminated}

--- a/lib/webrtc_transport.ex
+++ b/lib/webrtc_transport.ex
@@ -217,7 +217,11 @@ defmodule Mediasoup.WebRtcTransport do
   Tells whether the given WebRtcTransport is closed on the local node.
   """
   def closed?(%WebRtcTransport{pid: pid}) do
-    !Process.alive?(pid) || NifWrap.call(pid, {:closed?, []})
+    !Process.alive?(pid) ||
+      case NifWrap.call(pid, {:closed?, []}) do
+        {:error, :terminated} -> true
+        result -> result
+      end
   end
 
   @spec consume(t, Consumer.Options.t() | map()) ::

--- a/lib/worker.ex
+++ b/lib/worker.ex
@@ -102,6 +102,7 @@ defmodule Mediasoup.Worker do
   @doc """
   Worker identifier.
   """
+  @spec id(t) :: String.t() | {:error, :terminated}
   def id(pid) do
     NifWrap.call(pid, {:id, []})
   end
@@ -113,7 +114,8 @@ defmodule Mediasoup.Worker do
     GenServer.stop(pid)
   end
 
-  @spec create_router(t, Router.create_option()) :: {:ok, Router.t()} | {:error}
+  @spec create_router(t, Router.create_option()) ::
+          {:ok, Router.t()} | {:error} | {:error, :terminated}
   @doc """
     Creates a new router.
     https://mediasoup.org/documentation/v3/mediasoup/api/#worker-createRouter
@@ -126,6 +128,8 @@ defmodule Mediasoup.Worker do
     create_router(worker, Router.Options.from_map(option))
   end
 
+  @spec create_webrtc_server(any(), Mediasoup.WebRtcServer.Options.t()) ::
+          any() | {:error, :terminated}
   @doc """
     Creates a new WebRTC server.
     https://mediasoup.org/documentation/v3/mediasoup/api/#worker-createWebRtcServer
@@ -134,7 +138,7 @@ defmodule Mediasoup.Worker do
     NifWrap.call(pid, {:create_webrtc_server, [WebRtcServer.Options.normalize(option)]})
   end
 
-  @spec update_settings(t, update_option) :: {:ok} | {:error}
+  @spec update_settings(t, update_option) :: {:ok} | {:error} | {:error, :terminated}
   @doc """
     Updates the worker settings in runtime. Just a subset of the worker settings can be updated.
     https://mediasoup.org/documentation/v3/mediasoup/api/#worker-updateSettings
@@ -155,7 +159,7 @@ defmodule Mediasoup.Worker do
     !Process.alive?(pid)
   end
 
-  @spec dump(t) :: map
+  @spec dump(t) :: map | {:error, :terminated}
   @doc """
   Dump internal stat for Worker.
   """

--- a/lib/wrap.ex
+++ b/lib/wrap.ex
@@ -1,5 +1,8 @@
 defmodule Mediasoup.NifWrap do
-  @moduledoc false
+  @moduledoc """
+  Wrapper for calling GenServer that hosts NIF resource.
+  """
+
   # Utilities for wrap Nif
 
   @spec def_handle_call_nif(any) ::
@@ -50,9 +53,14 @@ defmodule Mediasoup.NifWrap do
 
   defmacro call(pid, args) do
     quote do
-      case GenServer.call(unquote(pid), unquote(args)) do
-        {:raise_error, e} -> raise e
-        result -> result
+      try do
+        case GenServer.call(unquote(pid), unquote(args)) do
+          {:raise_error, e} -> raise e
+          {:error} -> :error
+          result -> result
+        end
+      catch
+        :exit, e -> {:error, :terminated}
       end
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule MediasoupElixir.MixProject do
   use Mix.Project
 
-  @version "0.15.0"
+  @version "0.16.0"
   @repo "https://github.com/oviceinc/mediasoup-elixir"
   @description """
   Elixir wrapper for mediasoup


### PR DESCRIPTION
Because the producer/consumer process may terminate at any time.