### PR TITLE
Update mediasoup version to 0.19.1

### DIFF
--- a/lib/plain_transport.ex
+++ b/lib/plain_transport.ex
@@ -79,7 +79,8 @@ defmodule Mediasoup.PlainTransport do
         | listen_ip: nil,
           port: nil,
           listen_info:
-            Map.get(option, :listen_info) || TransportListenInfo.create(listen_ip, "udp", port),
+            Map.get(option, :listen_info) ||
+              TransportListenInfo.create(listen_ip, "udp", port),
           rtcp_listen_info:
             Map.get(option, :rtcp_listen_info) ||
               TransportListenInfo.create(listen_ip, "udp", nil)

--- a/lib/transport_listen_info.ex
+++ b/lib/transport_listen_info.ex
@@ -10,15 +10,28 @@ defmodule Mediasoup.TransportListenInfo do
   @type t :: %{
           :ip => String.t(),
           :protocol => :tcp | :udp,
+          :exposeInternalIp => boolean(),
           optional(:announcedAddress) => String.t() | nil,
           optional(:port) => integer(),
+          optional(:portRange) => map(),
+          optional(:flags) => map(),
           optional(:sendBufferSize) => integer(),
           optional(:recvBufferSize) => integer()
         }
 
   @enforce_keys [:ip, :protocol]
 
-  defstruct [:ip, :protocol, :announcedAddress, :port, :sendBufferSize, :recvBufferSize]
+  defstruct [
+    :ip,
+    :protocol,
+    :announcedAddress,
+    :exposeInternalIp,
+    :port,
+    :portRange,
+    :flags,
+    :sendBufferSize,
+    :recvBufferSize
+  ]
 
   def normalize_listen_ip(ip) when is_binary(ip) do
     %{:ip => ip}
@@ -43,7 +56,11 @@ defmodule Mediasoup.TransportListenInfo do
   @spec create(binary() | %{:ip => any(), optional(any()) => any()}, any()) :: struct()
   def create(ip, protocol) do
     listen_ip = normalize_listen_ip(ip)
-    struct(__MODULE__, Map.merge(listen_ip, %{:protocol => protocol}))
+
+    struct(
+      __MODULE__,
+      Map.merge(listen_ip, %{:protocol => protocol, :exposeInternalIp => false})
+    )
   end
 
   def create(ip, protocol, port) do
@@ -53,7 +70,8 @@ defmodule Mediasoup.TransportListenInfo do
       __MODULE__,
       Map.merge(listen_ip, %{
         :protocol => protocol,
-        :port => port
+        :port => port,
+        :exposeInternalIp => false
       })
     )
   end

--- a/lib/webrtc_server.ex
+++ b/lib/webrtc_server.ex
@@ -14,6 +14,7 @@ defmodule Mediasoup.WebRtcServer do
   @type webrtc_server_listen_info :: %{
           :protocol => :udp | :tcp,
           :ip => String.t(),
+          :exposeInternalIp => boolean(),
           optional(:announcedAddress) => String.t() | nil,
           optional(:announcedIp) => String.t() | nil,
           optional(:port) => integer() | nil

--- a/lib/webrtc_transport.ex
+++ b/lib/webrtc_transport.ex
@@ -135,7 +135,8 @@ defmodule Mediasoup.WebRtcTransport do
               protocol: protocol,
               ip: listen_ip.ip,
               announcedAddress: listen_ip[:announcedAddress],
-              port: port
+              port: port,
+              exposeInternalIp: listen_ip[:exposeInternalIp] || false
             }
           end)
         end)

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule MediasoupElixir.MixProject do
   use Mix.Project
 
-  @version "0.16.0"
+  @version "0.17.0"
   @repo "https://github.com/oviceinc/mediasoup-elixir"
   @description """
   Elixir wrapper for mediasoup

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{
   "bunt": {:hex, :bunt, "1.0.0", "081c2c665f086849e6d57900292b3a161727ab40431219529f13c4ddcf3e7a44", [:mix], [], "hexpm", "dc5f86aa08a5f6fa6b8096f0735c4e76d54ae5c9fa2c143e5a1fc7c1cd9bb6b5"},
-  "castore": {:hex, :castore, "1.0.14", "4582dd7d630b48cf5e1ca8d3d42494db51e406b7ba704e81fbd401866366896a", [], [], "hexpm", "7bc1b65249d31701393edaaac18ec8398d8974d52c647b7904d01b964137b9f4"},
+  "castore": {:hex, :castore, "1.0.14", "4582dd7d630b48cf5e1ca8d3d42494db51e406b7ba704e81fbd401866366896a", [:mix], [], "hexpm", "7bc1b65249d31701393edaaac18ec8398d8974d52c647b7904d01b964137b9f4"},
   "credo": {:hex, :credo, "1.7.12", "9e3c20463de4b5f3f23721527fcaf16722ec815e70ff6c60b86412c695d426c1", [:mix], [{:bunt, "~> 0.2.1 or ~> 1.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:file_system, "~> 0.2 or ~> 1.0", [hex: :file_system, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "8493d45c656c5427d9c729235b99d498bd133421f3e0a683e5c1b561471291e5"},
   "dialyxir": {:hex, :dialyxir, "1.4.5", "ca1571ac18e0f88d4ab245f0b60fa31ff1b12cbae2b11bd25d207f865e8ae78a", [:mix], [{:erlex, ">= 0.2.7", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "b0fb08bb8107c750db5c0b324fa2df5ceaa0f9307690ee3c1f6ba5b9eb5d35c3"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.44", "f20830dd6b5c77afe2b063777ddbbff09f9759396500cdbe7523efd58d7a339c", [:mix], [], "hexpm", "4778ac752b4701a5599215f7030989c989ffdc4f6df457c5f36938cc2d2a2750"},

--- a/native/mediasoup_elixir/Cargo.lock
+++ b/native/mediasoup_elixir/Cargo.lock
@@ -541,7 +541,7 @@ checksum = "45d0dbf6a9847b64c9b06938660891f983434dcc009b5ae6a58f5e34af74a649"
 dependencies = [
  "bitpattern",
  "log",
- "thiserror",
+ "thiserror 1.0.57",
 ]
 
 [[package]]
@@ -719,7 +719,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -781,9 +781,9 @@ checksum = "b6e8aaa3f231bb4bd57b84b2d5dc3ae7f350265df8aa96492e0bc394a1571909"
 
 [[package]]
 name = "mediasoup"
-version = "0.18.2"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e52735784e505a199137d1678cb3b045607413179628b950e51ae7a0ebef526a"
+checksum = "8d5a1ac2d0c7a0bc3ff20225c5ee0fa8498ddd3a7f04cf4b2aed4d4f3bdfb2bb"
 dependencies = [
  "async-channel",
  "async-executor",
@@ -799,6 +799,7 @@ dependencies = [
  "log",
  "lru",
  "mediasoup-sys",
+ "mediasoup-types",
  "nohash-hasher",
  "once_cell",
  "parking_lot 0.12.1",
@@ -807,15 +808,15 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
- "thiserror",
+ "thiserror 1.0.57",
  "uuid",
 ]
 
 [[package]]
 name = "mediasoup-sys"
-version = "0.9.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b865b9f888e55c7c814d0c15f0c0e010f1ce32f39b0b8147249600c1b3e7c142"
+checksum = "ca610ebc75215b7530027e3f1a171bb35337eff96b9e9df5ad19f189136df61f"
 dependencies = [
  "planus",
  "planus-codegen",
@@ -824,8 +825,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "mediasoup-types"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53ec9d899d198e0a9e992daef34a49f0031f1a2b44079e6a0ef6e91781b5b5bd"
+dependencies = [
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.16",
+]
+
+[[package]]
 name = "mediasoup_elixir"
-version = "3.14.2"
+version = "3.18.1"
 dependencies = [
  "async-executor",
  "env_logger",
@@ -1046,7 +1060,7 @@ dependencies = [
  "heck 0.4.1",
  "planus-types",
  "random_color",
- "thiserror",
+ "thiserror 1.0.57",
  "vec_map",
 ]
 
@@ -1215,7 +1229,7 @@ checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
  "getrandom 0.2.12",
  "libredox",
- "thiserror",
+ "thiserror 1.0.57",
 ]
 
 [[package]]
@@ -1472,7 +1486,16 @@ version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.57",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+dependencies = [
+ "thiserror-impl 2.0.16",
 ]
 
 [[package]]
@@ -1480,6 +1503,17 @@ name = "thiserror-impl"
 version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/native/mediasoup_elixir/Cargo.toml
+++ b/native/mediasoup_elixir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mediasoup_elixir"
-version = "3.14.2"
+version = "3.18.1"
 authors = []
 edition = "2021"
 
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 rustler = { version = "0.36.0", default-features = false, features = ["serde"] }
-mediasoup =  "0.18.2"
+mediasoup =  "0.19.1"
 futures-lite = "2.3.0"
 once_cell = "1.19.0"
 num_cpus = "1.16.0"

--- a/test/integration/test_pipe_transport.ex
+++ b/test/integration/test_pipe_transport.ex
@@ -402,12 +402,6 @@ defmodule IntegrateTest.PipeTransportTest do
            ] === pipe_consumer.rtp_parameters["codecs"]
 
     assert [
-             %{
-               "encrypt" => false,
-               "id" => 6,
-               "uri" => "http://tools.ietf.org/html/draft-ietf-avtext-framemarking-07"
-             },
-             %{"encrypt" => false, "id" => 7, "uri" => "urn:ietf:params:rtp-hdrext:framemarking"},
              %{"encrypt" => false, "id" => 11, "uri" => "urn:3gpp:video-orientation"},
              %{"encrypt" => false, "id" => 12, "uri" => "urn:ietf:params:rtp-hdrext:toffset"},
              %{
@@ -451,12 +445,6 @@ defmodule IntegrateTest.PipeTransportTest do
            ] === pipe_producer.rtp_parameters["codecs"]
 
     assert [
-             %{
-               "encrypt" => false,
-               "id" => 6,
-               "uri" => "http://tools.ietf.org/html/draft-ietf-avtext-framemarking-07"
-             },
-             %{"encrypt" => false, "id" => 7, "uri" => "urn:ietf:params:rtp-hdrext:framemarking"},
              %{"encrypt" => false, "id" => 11, "uri" => "urn:3gpp:video-orientation"},
              %{"encrypt" => false, "id" => 12, "uri" => "urn:ietf:params:rtp-hdrext:toffset"},
              %{
@@ -565,16 +553,6 @@ defmodule IntegrateTest.PipeTransportTest do
            ] === pipe_consumer.rtp_parameters["codecs"]
 
     assert [
-             %{
-               "encrypt" => false,
-               "id" => 6,
-               "uri" => "http://tools.ietf.org/html/draft-ietf-avtext-framemarking-07"
-             },
-             %{
-               "encrypt" => false,
-               "id" => 7,
-               "uri" => "urn:ietf:params:rtp-hdrext:framemarking"
-             },
              %{"encrypt" => false, "id" => 11, "uri" => "urn:3gpp:video-orientation"},
              %{"encrypt" => false, "id" => 12, "uri" => "urn:ietf:params:rtp-hdrext:toffset"},
              %{

--- a/test/integration/test_plain_transport.ex
+++ b/test/integration/test_plain_transport.ex
@@ -217,7 +217,10 @@ defmodule IntegrateTest.PlainTransportTest do
     {_worker, router} = init(worker)
 
     {:ok, transport} =
-      Router.create_plain_transport(router, %{listenIp: %{ip: "127.0.0.1"}, comedia: false})
+      Router.create_plain_transport(router, %{
+        listenIp: %{ip: "127.0.0.1"},
+        comedia: false
+      })
 
     assert transport.id == PlainTransport.id(transport)
 

--- a/test/integration/test_webrtc_server.ex
+++ b/test/integration/test_webrtc_server.ex
@@ -60,25 +60,29 @@ defmodule IntegrateTest.WebRtcServerTest do
             ip: "127.0.0.1",
             announcedIp: "9.9.9.1",
             port: 10111,
-            protocol: :tcp
+            protocol: :tcp,
+            exposeInternalIp: false
           },
           %{
             ip: "0.0.0.0",
             announcedIp: "9.9.9.2",
             port: 10112,
-            protocol: :tcp
+            protocol: :tcp,
+            exposeInternalIp: false
           },
           %{
             ip: "127.0.0.1",
             announcedIp: "9.9.9.1",
             port: 10111,
-            protocol: :udp
+            protocol: :udp,
+            exposeInternalIp: false
           },
           %{
             ip: "0.0.0.0",
             announcedIp: "9.9.9.2",
             port: 10112,
-            protocol: :udp
+            protocol: :udp,
+            exposeInternalIp: false
           }
         ]
       })
@@ -147,25 +151,29 @@ defmodule IntegrateTest.WebRtcServerTest do
             ip: "127.0.0.1",
             announcedIp: "9.9.9.1",
             port: 10111,
-            protocol: :tcp
+            protocol: :tcp,
+            exposeInternalIp: false
           },
           %{
             ip: "0.0.0.0",
             announcedIp: "9.9.9.2",
             port: 10112,
-            protocol: :tcp
+            protocol: :tcp,
+            exposeInternalIp: false
           },
           %{
             ip: "127.0.0.1",
             announcedIp: "9.9.9.1",
             port: 10111,
-            protocol: :udp
+            protocol: :udp,
+            exposeInternalIp: false
           },
           %{
             ip: "0.0.0.0",
             announcedIp: "9.9.9.2",
             port: 10112,
-            protocol: :udp
+            protocol: :udp,
+            exposeInternalIp: false
           }
         ]
       })
@@ -184,12 +192,14 @@ defmodule IntegrateTest.WebRtcServerTest do
           %{
             ip: "127.0.0.1",
             announcedIp: "9.9.9.1",
-            protocol: :udp
+            protocol: :udp,
+            exposeInternalIp: false
           },
           %{
             ip: "127.0.0.1",
             announcedIp: "9.9.9.2",
-            protocol: :tcp
+            protocol: :tcp,
+            exposeInternalIp: false
           }
         ]
       })
@@ -217,7 +227,8 @@ defmodule IntegrateTest.WebRtcServerTest do
         listen_infos: [
           %{
             ip: "1.2.3.4",
-            protocol: :udp
+            protocol: :udp,
+            exposeInternalIp: false
           }
         ]
       })
@@ -229,12 +240,14 @@ defmodule IntegrateTest.WebRtcServerTest do
           %{
             ip: "127.0.0.1",
             protocol: :udp,
-            port: 10111
+            port: 10111,
+            exposeInternalIp: false
           },
           %{
             ip: "127.0.0.1",
             protocol: :udp,
-            port: 10111
+            port: 10111,
+            exposeInternalIp: false
           }
         ]
       })
@@ -246,7 +259,8 @@ defmodule IntegrateTest.WebRtcServerTest do
           %{
             ip: "127.0.0.1",
             protocol: :udp,
-            port: 12348
+            port: 12348,
+            exposeInternalIp: false
           }
         ]
       })
@@ -257,7 +271,8 @@ defmodule IntegrateTest.WebRtcServerTest do
           %{
             ip: "127.0.0.1",
             protocol: :udp,
-            port: 12348
+            port: 12348,
+            exposeInternalIp: false
           }
         ]
       })

--- a/test/integration/test_webrtc_transport.ex
+++ b/test/integration/test_webrtc_transport.ex
@@ -459,25 +459,29 @@ defmodule IntegrateTest.WebRtcTransportTest do
             ip: "127.0.0.1",
             announcedIp: "9.9.9.1",
             port: 10111,
-            protocol: :tcp
+            protocol: :tcp,
+            exposeInternalIp: false
           },
           %{
             ip: "0.0.0.0",
             announcedIp: "9.9.9.2",
             port: 10112,
-            protocol: :tcp
+            protocol: :tcp,
+            exposeInternalIp: false
           },
           %{
             ip: "127.0.0.1",
             announcedIp: "9.9.9.1",
             port: 10111,
-            protocol: :udp
+            protocol: :udp,
+            exposeInternalIp: false
           },
           %{
             ip: "0.0.0.0",
             announcedIp: "9.9.9.2",
             port: 10112,
-            protocol: :udp
+            protocol: :udp,
+            exposeInternalIp: false
           }
         ]
       })

--- a/test/transport_listen_info_test.exs
+++ b/test/transport_listen_info_test.exs
@@ -7,14 +7,19 @@ defmodule Mediasoup.TransportListenInfoTest do
     assert %Mediasoup.TransportListenInfo{
              announcedAddress: "1.1.1.1",
              ip: "127.0.0.1",
-             protocol: :udp
+             protocol: :udp,
+             exposeInternalIp: false
            } ==
              TransportListenInfo.create(
                %{ip: "127.0.0.1", announcedAddress: "1.1.1.1"},
                :udp
              )
 
-    assert %Mediasoup.TransportListenInfo{ip: "127.0.0.1", protocol: :tcp} ==
+    assert %Mediasoup.TransportListenInfo{
+             ip: "127.0.0.1",
+             protocol: :tcp,
+             exposeInternalIp: false
+           } ==
              TransportListenInfo.create("127.0.0.1", :tcp)
   end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added exposeInternalIp option to listen info for WebRTC server and transports, defaulting to false, enabling finer control over internal IP exposure.
- Chores
  - Version bumps: project to 0.17.0; native crate and mediasoup dependency updated for compatibility.
- Tests
  - Updated test configurations to include exposeInternalIp; removed deprecated Framemarking RTP header extensions from expectations.
- Style
  - Minor formatting cleanups with no behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->