### PR TITLE
Exclude native target from release files due to exceed size limit

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -66,6 +66,7 @@ defmodule MediasoupElixir.MixProject do
       files: [
         "lib",
         "native/mediasoup_elixir/src",
+        "native/mediasoup_elixir/.cargo/config.toml",
         "native/mediasoup_elixir/Cargo.toml",
         "native/mediasoup_elixir/Cargo.lock",
         "native/mediasoup_elixir/Cross.toml",

--- a/mix.exs
+++ b/mix.exs
@@ -65,7 +65,11 @@ defmodule MediasoupElixir.MixProject do
       links: %{"Github" => @repo},
       files: [
         "lib",
-        "native",
+        "native/mediasoup_elixir/src",
+        "native/mediasoup_elixir/Cargo.toml",
+        "native/mediasoup_elixir/Cargo.lock",
+        "native/mediasoup_elixir/Cross.toml",
+        "native/mediasoup_elixir/README.md",
         "README.md",
         "checksum-*.exs",
         "mix.exs"


### PR DESCRIPTION
For https://github.com/oviceinc/mediasoup-elixir/actions/runs/23185849969/job/67371004462

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package metadata to more precisely include native implementation and build metadata components in the distributed package.
  * Packaging changes only; no functional or runtime behavior altered for end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->