### PR TITLE
Update elixir version to 1.18

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-elixir 1.17.3-otp-26
+elixir 1.18.4-otp-26
 erlang 26.2.5.16
 rust 1.93.0
 python 3.11.5

--- a/Dockerfile_dev
+++ b/Dockerfile_dev
@@ -1,4 +1,4 @@
-FROM elixir:1.17.3-otp-26
+FROM elixir:1.18.4-otp-26
 
 ENV RUST_VERSION=stable
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Elixir runtime from version 1.17.3 to 1.18.4 across development and production environments for improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->